### PR TITLE
fix build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "setuptools>=77.0.3",
     "wheel",
-    "packaging"
+    "packaging",
+    "torch"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
before:
```
(flash-attention-v100) flash-attention-v100 git:main  ❯ uv pip install . ⏎
Resolved 31 packages in 9ms
  × Failed to build `flash-attn-v100 @ file:///[...]/git/flash-attention-v100`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 15, in get_ext_modules
      ModuleNotFoundError: No module named 'torch'
```

after:
```
(flash-attention-v100) flash-attention-v100 git:main ✶  ❯ uv pip install .
Resolved 31 packages in 8ms
   Building flash-attn-v100 @ file:///[...]/git/flash-attention-v100
      Built flash-attn-v100 @ file:///[...]/git/flash-attention-v100
Prepared 1 package in 1m 55s
Installed 1 package in 1ms
```

fixes #24 