### PR TITLE
updating the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,21 @@ pip install -r requirements.txt
 As NVIDIA deprecated Volta support in CUDA since viersion 13 then PyTorch also restrict and deprecated support in new versions:  [PyTorch is dropping Volta support from CUDA-12.8 binaries for release 2.11](https://dev-discuss.pytorch.org/t/dropping-volta-support-from-cuda-12-8-binaries-for-release-2-11/) and check [PyTorch \[release 2.8-2.9\] delete support for Maxwell, Pascal, and Volta architectures for CUDA 12.8 and 12.9 builds](https://github.com/pytorch/pytorch/issues/157517)
 
 ```bash
-# Install last one PyTorch that's support with 12.9 CUDA
-pip install torch==2.10.0+cu129 --index-url https://download.pytorch.org/whl/cu129
+# Install last one PyTorch that's support with 12.9 CUDA and Volta architecture
+pip install torch==2.11.0+cu126 --index-url https://download.pytorch.org/whl/cu126
 
 # Check is package supports Volta
 python -c "import torch; p=torch.cuda.get_device_properties(0); print(f'{p.name} SM {p.major}.{p.minor} supported')"
 
-# If you will see Tesla V100-XXX-XXGB SM 7.0 supported all is done.
+# If you will see 'Tesla V100-XXX-XXGB SM 7.0 supported' all is done.
+
+# Install g++ (6 < Version g++ < 14) to build with CUDA 12.9, for example:
+yay -S gcc13
+# or
+apt install gcc13
+
+export CC=gcc-13 CXX=g++-13
+
 # We can compile and install project with just:
 
 ./run.sh 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=82.0.1",
+    "setuptools>77.0.3,<82.0.0",
     "wheel>=0.46.3",
     "packaging>=26.0",
-    "torch @ https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=a3c703e74a88cccfeb4b1807c49d563a0a73793ba72d4fa035d4ac5885f3aefd",
+    "torch @ https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl",
     "ninja>=1.13.0",
     "psutil>=7.2.2",
     "numpy>=2.4.4"
@@ -21,8 +21,8 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE", "AUTHORS"]
 dynamic = ["authors", "classifiers", "urls"]
 dependencies = [
-    "torch @ https://download-r2.pytorch.org/whl/cu129/torch-2.10.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=a3c703e74a88cccfeb4b1807c49d563a0a73793ba72d4fa035d4ac5885f3aefd",
-    "setuptools>=82.0.1",
+    "torch @ https://download-r2.pytorch.org/whl/cu126/torch-2.11.0%2Bcu126-cp313-cp313-manylinux_2_28_x86_64.whl",
+    "setuptools>77.0.3,<82.0.0",
     "wheel>=0.46.3",
     "packaging>=26.0",
     "ninja>=1.13.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ ninja==1.13.0
 numpy==2.4.4
 packaging==26.0
 psutil==7.2.2
-setuptools==82.0.1
+setuptools>77.0.3,<82.0.0
 sympy==1.14.0
 typing_extensions==4.15.0
 wheel==0.46.3
-

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_ext_modules():
     except ImportError as e:
         raise RuntimeError(
             "torch is required to build flash_attn_v100. "
-            "Please install torch >= 2.10 first (e.g., `pip install torch==2.10.0+cu129 --index-url https://download.pytorch.org/whl/cu129`)."
+            "Please install torch >= 2.10 first (e.g., `pip install torch==2.11.0+cu126 --index-url https://download.pytorch.org/whl/cu126`)."
         ) from e
 
     nvcc_threads = int(os.environ.get("NVCC_THREADS", 4))
@@ -102,7 +102,7 @@ def get_cmdclass():
     except ImportError as e:
         raise RuntimeError(
             "torch is required to build flash_attn_v100. "
-            "Please install torch >= 2.10 first (e.g., `pip install torch==2.10.0+cu129 --index-url https://download.pytorch.org/whl/cu129`)."
+            "Please install torch >= 2.10 first (e.g., `pip install torch==2.11.0+cu126 --index-url https://download.pytorch.org/whl/cu126`)."
         ) from e
 
     class BuildAttention(BuildExtension):
@@ -138,8 +138,8 @@ def get_cmdclass():
 
             if not torch.cuda.is_available():
                 raise RuntimeError("CUDA is required but not available.")
-            if parse(torch.version.cuda) < parse("12.9"):
-                raise RuntimeError(f"CUDA version {torch.version.cuda} < 12.9 is not supported.")
+            if parse(torch.version.cuda) < parse("12.6"):
+                raise RuntimeError(f"CUDA version {torch.version.cuda} < 12.6 is not supported.")
             super().build_extensions()
 
     return {"build_ext": BuildAttention, "build_py": CopyAttention, 'install': InstallAttention}


### PR DESCRIPTION
Hello.
I have a question about the relevance of the instructions in the [README](https://github.com/ai-bond/flash-attention-v100).
At the very first [link](https://dev-discuss.pytorch.org/t/dropping-volta-support-from-cuda-12-8-binaries-for-release-2-11/3290) what you cite in the 'Deployment and compilation' section says that Volta is now supported only in CUDA 12.6, which is confirmed in the description for [the latest torch release] (https://github.com/pytorch/pytorch/releases/tag/v2.11.0 ).
Also, to build a project with CUDA 12.9, you need g++ no later than version 13, to be more precise, then 6 < Version g++ < 14.

All test completed successfully on CUDA 12.9, Python 3.13, Torch 2.11.0+cu126, g++-13


