### PR TITLE
Forward/Backward: Add full features support for flash_attn_varlen_func() API

### DIFF
--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -1,7 +1,23 @@
-from flash_attn_v100 import flash_attn_func, flash_attn_gpu, __all__
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+from flash_attn_v100 import (
+    flash_attn_func,
+    flash_attn_gpu,
+    flash_attn_varlen_func,
+    flash_attn_varlen_gpu,
+    __version__ as _v100_version
+)
 
 __version__ = "2.8.3"
 
-__all__ = __all__ if '__all__' in locals() else ["flash_attn_func"]
-__version__ = __version__ if '__version__' in locals() else "2.8.3"
-__doc__ = f"Flash Attention for Tesla V100 v{__version__}"
+__all__ = [
+    "flash_attn_func",
+    "flash_attn_gpu",
+    "flash_attn_varlen_func",
+    "flash_attn_varlen_gpu",
+    "__version__"
+]
+
+__doc__ = f"Flash Attention for Tesla V100 v{__version__} (backend: v{_v100_version})"

--- a/flash_attn/bert_padding.py
+++ b/flash_attn/bert_padding.py
@@ -1,0 +1,147 @@
+# ======================================================================================
+# * Copyright (c) 2023, Tri Dao / Adapted for Volta FA2
+# * SPDX-License-Identifier: BSD-3-Clause
+# ======================================================================================
+import torch
+import torch.nn.functional as F
+from einops import rearrange, repeat
+
+class IndexFirstAxis(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+        ctx.save_for_backward(indices)
+        assert input.ndim >= 2
+        ctx.first_axis_dim, other_shape = input.shape[0], input.shape[1:]
+        second_dim = other_shape.numel()
+        return torch.gather(
+            rearrange(input, "b ... -> b (...)"), 0, repeat(indices, "z -> z d", d=second_dim)
+        ).reshape(-1, *other_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (indices,) = ctx.saved_tensors
+        assert grad_output.ndim >= 2
+        other_shape = grad_output.shape[1:]
+        grad_output = rearrange(grad_output, "b ... -> b (...)")
+        grad_input = torch.zeros(
+            [ctx.first_axis_dim, grad_output.shape[1]],
+            device=grad_output.device,
+            dtype=grad_output.dtype,
+        )
+        grad_input.scatter_(0, repeat(indices, "z -> z d", d=grad_output.shape[1]), grad_output)
+        return grad_input.reshape(ctx.first_axis_dim, *other_shape), None
+
+index_first_axis = IndexFirstAxis.apply
+
+
+class IndexPutFirstAxis(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, values: torch.Tensor, indices: torch.Tensor, first_axis_dim: int) -> torch.Tensor:
+        ctx.save_for_backward(indices)
+        assert indices.ndim == 1
+        assert values.ndim >= 2
+        output = torch.zeros(first_axis_dim, *values.shape[1:], device=values.device, dtype=values.dtype)
+        output[indices] = values
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (indices,) = ctx.saved_tensors
+        return grad_output[indices], None, None
+
+index_put_first_axis = IndexPutFirstAxis.apply
+
+
+class IndexFirstAxisResidual(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input: torch.Tensor, indices: torch.Tensor):
+        ctx.save_for_backward(indices)
+        assert input.ndim >= 2
+        ctx.first_axis_dim, other_shape = input.shape[0], input.shape[1:]
+        output = input[indices]
+        return output, input.detach()
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor, grad_residual: torch.Tensor):
+        (indices,) = ctx.saved_tensors
+        assert grad_output.ndim >= 2
+        other_shape = grad_output.shape[1:]
+        assert grad_residual.shape[1:] == other_shape
+        grad_input = grad_residual
+        indices = indices.reshape(indices.shape[0], *((1,) * (grad_output.ndim - 1)))
+        indices = indices.expand_as(grad_output)
+        grad_input.scatter_add_(0, indices, grad_output)
+        return grad_input.reshape(ctx.first_axis_dim, *other_shape), None
+
+index_first_axis_residual = IndexFirstAxisResidual.apply
+
+
+def unpad_input(hidden_states: torch.Tensor, attention_mask: torch.Tensor, unused_mask: torch.Tensor = None):
+    """
+    Converts padded input to ragged (varlen) format.
+    Args:
+        hidden_states: (batch, seqlen, ...)
+        attention_mask: (batch, seqlen), bool/int. 1 = valid, 0 = masked.
+        unused_mask: (batch, seqlen), optional. 1 = allocated but unused.
+    Returns:
+        hidden_states: (total_nnz, ...)
+        indices: (total_nnz,)
+        cu_seqlens: (batch + 1,), int32
+        max_seqlen_in_batch: int
+        seqlens: (batch,), int32
+    """
+    all_masks = (attention_mask + unused_mask) if unused_mask is not None else attention_mask
+    seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+    max_seqlen_in_batch = seqlens_in_batch.max().item()
+    cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+    return (
+        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
+        indices,
+        cu_seqlens,
+        max_seqlen_in_batch,
+        seqlens_in_batch,
+    )
+
+
+def unpad_input_for_concatenated_sequences(hidden_states: torch.Tensor, attention_mask_in_length: torch.Tensor):
+    """
+    Supports concatenating short samples in one sequence.
+    Args:
+        hidden_states: (batch, seqlen, ...)
+        attention_mask_in_length: (batch, seqlen), int. Nonzero = length of concatenated sequence.
+    Returns:
+        hidden_states: (total_nnz, ...)
+        indices: (total_nnz,)
+        cu_seqlens: (batch + 1,), int32
+        max_seqlen_in_batch: int
+    """
+    length = attention_mask_in_length.sum(dim=-1)
+    seqlen = attention_mask_in_length.size(-1)
+    attention_mask_2d = torch.arange(seqlen, device=length.device, dtype=length.dtype).expand(len(length), seqlen) < length.unsqueeze(1)
+    real_indices_idx = torch.nonzero(attention_mask_in_length.flatten(), as_tuple=False).flatten()
+    seqlens_in_batch = attention_mask_in_length.flatten()[real_indices_idx]
+    indices = torch.nonzero(attention_mask_2d.flatten(), as_tuple=False).flatten()
+    max_seqlen_in_batch = seqlens_in_batch.max().item()
+    cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+    return (
+        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
+        indices,
+        cu_seqlens,
+        max_seqlen_in_batch,
+    )
+
+
+def pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch: int, seqlen: int) -> torch.Tensor:
+    """
+    Converts ragged (varlen) output back to padded format.
+    Args:
+        hidden_states: (total_nnz, ...)
+        indices: (total_nnz,)
+        batch: int
+        seqlen: int
+    Returns:
+        hidden_states: (batch, seqlen, ...)
+    """
+    output = index_put_first_axis(hidden_states, indices, batch * seqlen)
+    return rearrange(output, "(b s) ... -> b s ...", b=batch)

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -1,6 +1,13 @@
-from flash_attn_v100 import flash_attn_func, flash_attn_gpu
+from flash_attn_v100.flash_attn_interface import (
+    flash_attn_func,
+    flash_attn_gpu,
+    flash_attn_varlen_func,
+    flash_attn_varlen_gpu
+)
 
-flash_attn_gpu = flash_attn_gpu
-flash_attn_func = flash_attn_func
-
-__all__ = ["flash_attn_gpu", "flash_attn_func"]
+__all__ = [
+    "flash_attn_func",
+    "flash_attn_gpu",
+    "flash_attn_varlen_func",
+    "flash_attn_varlen_gpu"
+]

--- a/flash_attn_v100/__init__.py
+++ b/flash_attn_v100/__init__.py
@@ -1,5 +1,15 @@
 __version__ = "26.04"
 
-from .flash_attn_interface import flash_attn_func, flash_attn_gpu
+from .flash_attn_interface import (
+    flash_attn_func,
+    flash_attn_gpu,
+    flash_attn_varlen_func,
+    flash_attn_varlen_gpu
+)
 
-__all__ = ["flash_attn_func", "flash_attn_gpu"]
+__all__ = [
+    "flash_attn_func",
+    "flash_attn_gpu",
+    "flash_attn_varlen_func",
+    "flash_attn_varlen_gpu"
+]

--- a/flash_attn_v100/flash_attn_interface.py
+++ b/flash_attn_v100/flash_attn_interface.py
@@ -1,7 +1,7 @@
-# *
+# ======================================================================================
 # * Copyright (c) 2026, D.Skryabin / tg @ai_bond007
 # * SPDX-License-Identifier: BSD-3-Clause
-# *
+# ======================================================================================
 import torch
 import warnings
 import traceback
@@ -11,6 +11,9 @@ from typing import Optional, Tuple
 def maybe_contiguous(x: torch.Tensor) -> torch.Tensor:
     return x.contiguous() if x is not None and not x.is_contiguous() else x
 
+# ======================================================================================
+# DENSE ATTENTION (B, M, H, D) -> (B, H, M, D)
+# ======================================================================================
 class FlashAttnFunc(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -35,15 +38,12 @@ class FlashAttnFunc(torch.autograd.Function):
         H_K = k_.shape[1]
         N = k_.shape[2]
 
+        pad_size = 0
         if head_size_og % 8 != 0:
             pad_size = 8 - head_size_og % 8
             q_ = torch.nn.functional.pad(q_, [0, pad_size])
             k_ = torch.nn.functional.pad(k_, [0, pad_size])
             v_ = torch.nn.functional.pad(v_, [0, pad_size])
-            head_size = head_size_og + pad_size
-        else:
-            head_size = head_size_og
-            pad_size = 0
 
         q_ = q_.contiguous()
         k_ = k_.contiguous()
@@ -52,14 +52,13 @@ class FlashAttnFunc(torch.autograd.Function):
         if softmax_scale is None:
             softmax_scale = head_size_og ** -0.5
 
-        window_left, window_size_right = window_size
+        window_left, window_right = window_size
 
         out_, lse_, dmask_, rng_state = flash_attn_v100_cuda.fwd(
-            q_, k_, v_,
-            None, alibi_slopes,
+            q_, k_, v_, None, alibi_slopes,
             dropout_p, softmax_scale, causal,
-            window_left, window_size_right,
-            softcap, return_attn_probs, None
+            window_left, window_right, softcap,
+            return_attn_probs, None
         )
 
         out = out_[..., :head_size_og].permute(0, 2, 1, 3).contiguous()
@@ -103,11 +102,12 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.softcap, ctx.deterministic, None, rng_state
         )
 
-        dq = grads[0][..., :head_size_og].permute(0, 2, 1, 3)
-        dk = grads[1][..., :head_size_og].permute(0, 2, 1, 3)
-        dv = grads[2][..., :head_size_og].permute(0, 2, 1, 3)
+        dq = grads[0][..., :head_size_og].permute(0, 2, 1, 3).contiguous()
+        dk = grads[1][..., :head_size_og].permute(0, 2, 1, 3).contiguous()
+        dv = grads[2][..., :head_size_og].permute(0, 2, 1, 3).contiguous()
 
         return dq, dk, dv, None, None, None, None, None, None, None, None
+
 
 def flash_attn_func(
     q: torch.Tensor,
@@ -122,56 +122,178 @@ def flash_attn_func(
     deterministic: bool = False,
     return_attn_probs: bool = False
 ):
-    """
-    dropout_p should be set to 0.0 during evaluation
-    Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
-    than Q. Note that the number of heads in Q must be divisible by the number of heads in KV.
-    For example, if Q has 6 heads and K, V have 2 heads, head 0, 1, 2 of Q will attention to head
-    0 of K, V, and head 3, 4, 5 of Q will attention to head 1 of K, V.
-    If window_size != (-1, -1), implements sliding window local attention. Query at position i
-    will only attend to keys between
-    [i + seqlen_k - seqlen_q - window_size[0], i + seqlen_k - seqlen_q + window_size[1]] inclusive.
-
-    Arguments:
-        q: (batch_size, seqlen, nheads, headdim)
-        k: (batch_size, seqlen, nheads_k, headdim)
-        v: (batch_size, seqlen, nheads_k, headdim)
-        dropout_p: float. Dropout probability.
-        softmax_scale: float. The scaling of QK^T before applying softmax.
-            Default to 1 / sqrt(headdim).
-        causal: bool. Whether to apply causal attention mask (e.g., for auto-regressive modeling).
-        window_size: (left, right). If not (-1, -1), implements sliding window local attention.
-        alibi_slopes: (nheads,) or (batch_size, nheads), fp32. A bias of
-            (-alibi_slope * |i + seqlen_k - seqlen_q - j|)
-            is added to the attention score of query i and key j.
-        deterministic: bool. Whether to use the deterministic implementation of the backward pass,
-            which is slightly slower and uses more memory. The forward pass is always deterministic.
-    Return:
-        out: (batch_size, seqlen, nheads, headdim).
-    """
-
+    """Dense Flash Attention (B, M, H, D)"""
     if deterministic:
-        warnings.warn("The forward pass is always deterministic. Deterministic backward is not supported.", RuntimeWarning)
+        warnings.warn("Forward is always deterministic. Deterministic backward is not supported.", RuntimeWarning)
         deterministic = False
 
     try:
         return FlashAttnFunc.apply(
-            q,
-            k,
-            v,
-            dropout_p,
-            softmax_scale,
-            causal,
-            window_size,
-            softcap,
-            alibi_slopes,
-            deterministic,
-            return_attn_probs
+            q, k, v, dropout_p, softmax_scale, causal,
+            window_size, softcap, alibi_slopes, deterministic, return_attn_probs
         )
     except Exception as e:
-        print(f"[VOLTA FA2 FAILED] {type(e).__name__}: {e}")
+        print(f"[VOLTA FA2 DENSE FAILED] {type(e).__name__}: {e}")
         traceback.print_exc()
         raise
 
+
+# ======================================================================================
+# VARLEN ATTENTION (T, H, D) -> (T, H, D)
+# ======================================================================================
+class FlashAttnVarlenFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size: Tuple[int, int],
+        softcap: float,
+        alibi_slopes: Optional[torch.Tensor],
+        deterministic: bool,
+        return_attn_probs: bool,
+        block_table: Optional[torch.Tensor],
+        seqused_k: Optional[torch.Tensor],
+        leftpad_k: Optional[torch.Tensor],
+        is_grad_enabled: bool
+    ) -> torch.Tensor:
+        cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+        cu_seqlens_k = cu_seqlens_k.to(torch.int32)
+
+        q = maybe_contiguous(q)
+        k = maybe_contiguous(k)
+        v = maybe_contiguous(v)
+
+        head_size_og = q.size(2)
+        pad_size = 0
+        if head_size_og % 8 != 0:
+            pad_size = 8 - head_size_og % 8
+            q = torch.nn.functional.pad(q, [0, pad_size])
+            k = torch.nn.functional.pad(k, [0, pad_size])
+            v = torch.nn.functional.pad(v, [0, pad_size])
+
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+
+        if softmax_scale is None:
+            softmax_scale = head_size_og ** -0.5
+
+        window_left, window_right = window_size
+
+        out, lse, dmask, rng_state = flash_attn_v100_cuda.varlen_fwd(
+            q, k, v, None, cu_seqlens_q, cu_seqlens_k,
+            seqused_k, leftpad_k, block_table, alibi_slopes,
+            max_seqlen_q, max_seqlen_k, dropout_p, softmax_scale,
+            False, causal, window_left, window_right, softcap,
+            return_attn_probs and dropout_p > 0.0, None, 0
+        )
+
+        out = out[..., :head_size_og].contiguous()
+
+        if is_grad_enabled and (q.requires_grad or k.requires_grad or v.requires_grad):
+            ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, rng_state)
+            ctx.dropout_p = dropout_p
+            ctx.softmax_scale = softmax_scale
+            ctx.causal = causal
+            ctx.window_size = window_size
+            ctx.softcap = softcap
+            ctx.alibi_slopes = alibi_slopes
+            ctx.deterministic = deterministic
+            ctx.head_size_og = head_size_og
+            ctx.pad_size = pad_size
+            ctx.max_seqlen_q = max_seqlen_q
+            ctx.max_seqlen_k = max_seqlen_k
+
+        return (out, lse, dmask) if return_attn_probs else out
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+        q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
+        head_size_og = ctx.head_size_og
+        pad_size = ctx.pad_size
+
+        cu_seqlens_q = cu_seqlens_q.to(torch.int32)
+        cu_seqlens_k = cu_seqlens_k.to(torch.int32)
+
+        dout = maybe_contiguous(dout)
+        if pad_size > 0:
+            dout = torch.nn.functional.pad(dout, [0, pad_size])
+        dout = dout.contiguous()
+
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+
+        window_left, window_right = ctx.window_size
+
+        grads = flash_attn_v100_cuda.varlen_bwd(
+            dout, q, k, v, out, lse,
+            dq, dk, dv, cu_seqlens_q, cu_seqlens_k,
+            ctx.alibi_slopes, ctx.max_seqlen_q, ctx.max_seqlen_k,
+            ctx.dropout_p, ctx.softmax_scale, False,
+            ctx.causal, window_left, window_right, ctx.softcap,
+            ctx.deterministic, None, rng_state
+        )
+
+        dq = grads[0][..., :head_size_og].contiguous()
+        dk = grads[1][..., :head_size_og].contiguous()
+        dv = grads[2][..., :head_size_og].contiguous()
+
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+
+
+def flash_attn_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float = 0.0,
+    softmax_scale: float = None,
+    causal: bool = False,
+    window_size: Tuple[int, int] = (-1, -1),
+    softcap: float = 0.0,
+    alibi_slopes: Optional[torch.Tensor] = None,
+    deterministic: bool = False,
+    return_attn_probs: bool = False,
+    block_table: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    leftpad_k: Optional[torch.Tensor] = None
+):
+    """Varlen Flash Attention (T, H, D)"""
+    if deterministic:
+        warnings.warn("Forward is always deterministic. Deterministic backward is not supported.", RuntimeWarning)
+        deterministic = False
+
+    try:
+        return FlashAttnVarlenFunc.apply(
+            q, k, v, cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q, max_seqlen_k, dropout_p, softmax_scale, causal,
+            window_size, softcap, alibi_slopes, deterministic,
+            return_attn_probs, block_table, seqused_k, leftpad_k,
+            torch.is_grad_enabled()
+        )
+    except Exception as e:
+        print(f"[VOLTA FA2 VARLEN FAILED] {type(e).__name__}: {e}")
+        traceback.print_exc()
+        raise
+
+
 flash_attn_gpu = flash_attn_func
-__all__ = ["flash_attn_func", "flash_attn_gpu"]
+flash_attn_varlen_gpu = flash_attn_varlen_func
+
+__all__ = [
+    "flash_attn_func", "flash_attn_gpu",
+    "flash_attn_varlen_func", "flash_attn_varlen_gpu"
+]

--- a/include/gemm_smem.h
+++ b/include/gemm_smem.h
@@ -33,23 +33,27 @@ __device__ __forceinline__ void WMMA_GEMM_INIT_SMEM(char* smem_raw) {
 }
 
 // ======================================================================================
-// TILE LOADER (Single or Dual load, with internal casting)
-// Loads uint4-vectorized tiles from global memory to shared memory with bounds checking.
+// TILE LOADER: Global-shared load with decoupled stride/width for varlen/dense layouts.
+//   DUAL_LOAD:     Loads two independent buffers (GMEM0->SMEM0, GMEM1->SMEM1).
+//   SMEM_STRIDE:   Shared memory pitch (uint4-aligned), decoupled from global stride.
+//   GLOBAL_WIDTH:  Sub-tile column width for varlen; -1 falls back to GLOBAL_STRIDE.
 // ======================================================================================
-template<typename Config, bool DUAL_LOAD, int DST_STRIDE>
+template<typename Config, bool DUAL_LOAD, int SMEM_STRIDE, int GLOBAL_WIDTH = -1>
 __device__ __forceinline__ void WMMA_GEMM_LOAD_TILE(
     const __half* __restrict__ GMEM0,
           __half* __restrict__ SMEM0,
     const __half* __restrict__ GMEM1,
           __half* __restrict__ SMEM1,
-    int SRC_STRIDE,
+    int GLOBAL_STRIDE,
     int VALID_ROWS,
     int THREAD_ID
 ) {
     constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int dst_stride_uint4  = (DST_STRIDE + 7) >> 3;
-    const     int src_stride_uint4  = (SRC_STRIDE + 7) >> 3;
-    const     int total_iters       = VALID_ROWS * src_stride_uint4;
+    constexpr int dst_stride_uint4  = (SMEM_STRIDE + 7) >> 3;
+    const     int wth_stride_uint4  = (((GLOBAL_WIDTH > 0) ? GLOBAL_WIDTH : GLOBAL_STRIDE) + 7) >> 3;
+    const     int src_stride_uint4  = (GLOBAL_STRIDE + 7) >> 3;
+
+    const     int total_iters       = VALID_ROWS * wth_stride_uint4;
 
     if (total_iters == 0) return;
 
@@ -65,8 +69,8 @@ __device__ __forceinline__ void WMMA_GEMM_LOAD_TILE(
 
     #pragma unroll 2
     for (int idx = THREAD_ID; idx < total_iters; idx += THREADS_PER_BLOCK) {
-        const int row = idx / src_stride_uint4;
-        const int col = idx % src_stride_uint4;
+        const int row = idx / wth_stride_uint4;
+        const int col = idx % wth_stride_uint4;
 
         const int src_offset = row * src_stride_uint4 + col;
         const int dst_offset = row * dst_stride_uint4 + col;

--- a/include/gemm_smem.h
+++ b/include/gemm_smem.h
@@ -33,10 +33,10 @@ __device__ __forceinline__ void WMMA_GEMM_INIT_SMEM(char* smem_raw) {
 }
 
 // ======================================================================================
-// TILE LOADER: Global-shared load with decoupled stride/width for varlen/dense layouts.
-//   DUAL_LOAD:     Loads two independent buffers (GMEM0->SMEM0, GMEM1->SMEM1).
-//   SMEM_STRIDE:   Shared memory pitch (uint4-aligned), decoupled from global stride.
-//   GLOBAL_WIDTH:  Sub-tile column width for varlen; -1 falls back to GLOBAL_STRIDE.
+// TILE LOADER: Global-shared load with decoupled stride/width for varlen/dense layouts
+//   DUAL_LOAD:     Loads two independent buffers (GMEM0->SMEM0, GMEM1->SMEM1)
+//   SMEM_STRIDE:   Shared memory pitch (uint4-aligned), decoupled from global stride
+//   GLOBAL_WIDTH:  Sub-tile column width for varlen; -1 falls back to GLOBAL_STRIDE
 // ======================================================================================
 template<typename Config, bool DUAL_LOAD, int SMEM_STRIDE, int GLOBAL_WIDTH = -1>
 __device__ __forceinline__ void WMMA_GEMM_LOAD_TILE(
@@ -110,9 +110,12 @@ __device__ __forceinline__ void WMMA_GEMM_LOAD_TILE(
 }
 
 // ============================================================================
-// KERNEL_EPILOGUE
+// KERNEL EPILOGUE:   Shared-global fp32->fp16 store with optional norm & dual output
+//   TYPE (GemmType): NORMLZE (bit 0) rescales by 1/SMEM_DOT[row]; DUAL_STORE (bit 1) writes SMEM1->GMEM1
+//   SMEM_STRIDE:     Shared memory pitch (float4-aligned), decoupled from global stride
+//   GLOBAL_WIDTH:    Sub-tile column width for varlen; -1 falls back to GLOBAL_STRIDE
 // ============================================================================
-template<typename Config, GemmType TYPE, int SMEM_STRIDE>
+template<typename Config, GemmType TYPE, int SMEM_STRIDE, int GLOBAL_WIDTH = -1 >
 __device__ __forceinline__ void WMMA_GEMM_EPILOGUE(
     const float* __restrict__ SMEM0,
          __half* __restrict__ GMEM0,
@@ -123,8 +126,7 @@ __device__ __forceinline__ void WMMA_GEMM_EPILOGUE(
     int VALID_ROWS,
     int THREAD_ID
 ) {
-
-    const int global_chunks = GLOBAL_STRIDE >> 2;
+    const int global_chunks = ((GLOBAL_WIDTH > 0) ? GLOBAL_WIDTH : GLOBAL_STRIDE) >> 2;
     const int total_iters   = VALID_ROWS * global_chunks;
 
     if (total_iters == 0) return;

--- a/include/mha.h
+++ b/include/mha.h
@@ -9,60 +9,60 @@
 /**
  * Flash Attention Forward Pass
  *
- * @param q                   Query tensor           [B, H, M, D] (fp16, input)
- * @param k                   Key tensor             [B, H, N, D] (fp16, input)
- * @param v                   Value tensor           [B, H, N, D] (fp16, input)
- * @param out                 Optional output tensor [B, H, M, D] (fp16, output)
- * @param alibi_slopes        Optional ALiBi slopes tensor for relative positioning
- * @param p_dropout           Dropout probability (0.0 for no dropout)
- * @param softmax_scale       Softmax scale (typically 1/sqrt(D))
- * @param is_causal           Enable causal masking (autoregressive)
- * @param window_left         Left window size for sliding window attention
- * @param window_right        Right window size for sliding window attention
- * @param softcap             Soft capping value for attention scores
- * @param return_softmax      Whether to return softmax matrix (memory intensive)
- * @param gen                 Optional random generator for dropout
- * @return                    Vector of output tensors [output, softmax_lse, ...]
+ * @param q                   Query tensor                     [B, H, M, D] (fp16, input)
+ * @param k                   Key tensor                       [B, H, N, D] (fp16, input)
+ * @param v                   Value tensor                     [B, H, N, D] (fp16, input)
+ * @param out                 Optional output tensor           [B, H, M, D] (fp16, output)
+ * @param alibi_slopes        Optional ALiBi slopes tensor     [H] or [B,H] (fp32, input)
+ * @param p_dropout           Dropout probability              (float, input)
+ * @param softmax_scale       Softmax scale factor             (float, input)
+ * @param is_causal           Enable causal masking            (bool, input)
+ * @param window_left         Left window size for sliding attn(int, input)
+ * @param window_right        Right window size for sliding attn(int, input)
+ * @param softcap             Soft capping value for logits    (float, input)
+ * @param return_softmax      Whether to return softmax matrix (bool, input)
+ * @param gen                 Optional RNG for dropout         (input)
+ * @return                    Vector of output tensors {out, softmax_lse, dmask, rng_state}
  */
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
+          at::Tensor& q,
     const at::Tensor& k,
     const at::Tensor& v,
     std::optional<at::Tensor>& out,
     std::optional<at::Tensor>& alibi_slopes,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_left,
-    int window_right,
-    const float softcap,
-    const bool return_softmax,
+    const float  p_dropout,
+    const float  softmax_scale,
+    bool         is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool   return_softmax,
     std::optional<at::Generator> gen
 );
 
 /**
  * Flash Attention Backward Pass
  *
- * @param dout          Gradient output             [B, H, M, D] (fp16, input)
- * @param q             Query tensor from forward   [B, H, M, D] (fp16, input)
- * @param k             Key tensor from forward     [B, H, N, D] (fp16, input)
- * @param v             Value tensor from forward   [B, H, N, D] (fp16, input)
- * @param out           Output from forward pass    [B, H, M, D] (fp16, input)
- * @param softmax_lse   Forward's Softmax logsumexp [B, H, M]    (fp32, input)
- * @param dq            Optional gradient query     [B, H, M, D] (fp16, output)
- * @param dk            Optional gradient key       [B, H, N, D] (fp16, output)
- * @param dv            Optional gradient value     [B, H, N, D] (fp16, output)
- * @param alibi_slopes  Optional ALiBi slopes tensor (must match forward)
- * @param p_dropout     Dropout probability (must match forward)
- * @param softmax_scale Softmax scale (must match forward)
- * @param is_causal     Causal masking flag (must match forward)
- * @param window_left   Left window size (must match forward)
- * @param window_right  Right window size (must match forward)
- * @param softcap       Soft capping value (must match forward)
- * @param deterministic Whether to use deterministic backward pass
- * @param gen           Optional random generator for dropout
- * @param rng_state     Optional RNG state for reproducibility
- * @return              Vector of gradient tensors [dq, dk, dv, ...]
+ * @param dout                Gradient output                  [B, H, M, D] (fp16, input)
+ * @param q                   Query tensor from forward        [B, H, M, D] (fp16, input)
+ * @param k                   Key tensor from forward          [B, H, N, D] (fp16, input)
+ * @param v                   Value tensor from forward        [B, H, N, D] (fp16, input)
+ * @param out                 Output from forward pass         [B, H, M, D] (fp16, input)
+ * @param softmax_lse         Forward's Softmax logsumexp      [B, H, M]    (fp32, input)
+ * @param dq                  Optional gradient query          [B, H, M, D] (fp16, output)
+ * @param dk                  Optional gradient key            [B, H, N, D] (fp16, output)
+ * @param dv                  Optional gradient value          [B, H, N, D] (fp16, output)
+ * @param alibi_slopes        Optional ALiBi slopes tensor     (must match forward)
+ * @param p_dropout           Dropout probability              (must match forward)
+ * @param softmax_scale       Softmax scale factor             (must match forward)
+ * @param is_causal           Causal masking flag              (must match forward)
+ * @param window_left         Left window size                 (must match forward)
+ * @param window_right        Right window size                (must match forward)
+ * @param softcap             Soft capping value               (must match forward)
+ * @param deterministic       Use deterministic backward pass  (bool, input)
+ * @param gen                 Optional RNG for dropout         (input)
+ * @param rng_state           Optional RNG state for repro     (input)
+ * @return                    Vector of gradient tensors {dq, dk, dv, softmax_d}
  */
 std::vector<at::Tensor> flash_attention_backward(
     const at::Tensor& dout,
@@ -75,13 +75,65 @@ std::vector<at::Tensor> flash_attention_backward(
     std::optional<at::Tensor>& dk,
     std::optional<at::Tensor>& dv,
     std::optional<at::Tensor>& alibi_slopes,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_left,
-    int window_right,
-    const float softcap,
-    const bool deterministic,
+    const float  p_dropout,
+    const float  softmax_scale,
+    const bool   is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool   deterministic,
     std::optional<at::Generator> gen,
     std::optional<at::Tensor>& rng_state
+);
+
+/**
+ * FlashAttention Forward Pass (Varlen / Packed Layout)
+ *
+ * @param q                   Query tensor                     [total_q, H, D] (fp16, input)
+ * @param k                   Key tensor                       [total_k, H, D] (fp16, input)
+ * @param v                   Value tensor                     [total_k, H, D] (fp16, input)
+ * @param out                 Optional output tensor           [total_q, H, D] (fp16, output)
+ * @param cu_seqlens_q        Cumulative seq lengths for Q     [B+1] (int32, input)
+ * @param cu_seqlens_k        Cumulative seq lengths for K     [B+1] (int32, input)
+ * @param seqused_k           Optional actual seq lengths for K[B]   (int32, input)
+ * @param leftpad_k           Optional left padding for K      [B]   (int32, input)
+ * @param block_table         Optional block table for paged attn[B, max_blocks] (int32, input)
+ * @param alibi_slopes        Optional ALiBi slopes tensor     [H] or [B,H] (fp32, input)
+ * @param max_seqlen_q        Maximum sequence length for Q    (int, input)
+ * @param max_seqlen_k        Maximum sequence length for K    (int, input)
+ * @param p_dropout           Dropout probability              (float, input)
+ * @param softmax_scale       Softmax scale factor             (float, input)
+ * @param zero_tensors        Zero output tensors before compute(bool, input)
+ * @param is_causal           Enable causal masking            (bool, input)
+ * @param window_left         Left window size for sliding attn(int, input)
+ * @param window_right        Right window size for sliding attn(int, input)
+ * @param softcap             Soft capping value for logits    (float, input)
+ * @param return_softmax      Whether to return softmax matrix (bool, input)
+ * @param gen                 Optional RNG for dropout         (input)
+ * @param num_splits          KV-cache split heuristic         (int, input)
+ * @return                    Vector of output tensors {out, softmax_lse, dmask, rng_state}
+ */
+std::vector<at::Tensor> flash_attention_varlen_forward(
+          at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    std::optional<at::Tensor> &out,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    std::optional<at::Tensor> &seqused_k,
+    std::optional<const at::Tensor> &leftpad_k,
+    std::optional<at::Tensor> &block_table,
+    std::optional<at::Tensor> alibi_slopes,
+    int          max_seqlen_q,
+    const int    max_seqlen_k,
+    const float  p_dropout,
+    const float  softmax_scale,
+    const bool   zero_tensors,
+    bool         is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool   return_softmax,
+    std::optional<at::Generator> gen,
+    int          num_splits = 0
 );

--- a/include/mha.h
+++ b/include/mha.h
@@ -137,3 +137,59 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
     std::optional<at::Generator> gen,
     int          num_splits = 0
 );
+
+/**
+ * FlashAttention Backward Pass (Varlen / Packed Layout)
+ *
+ * @param dout                Gradient output                  [total_q, H, D] (fp16, input)
+ * @param q                   Query tensor from forward        [total_q, H, D] (fp16, input)
+ * @param k                   Key tensor from forward          [total_k, H, D] (fp16, input)
+ * @param v                   Value tensor from forward        [total_k, H, D] (fp16, input)
+ * @param out                 Output from forward pass         [total_q, H, D] (fp16, input)
+ * @param softmax_lse         Forward's Softmax logsumexp      [total_q, H]    (fp32, input)
+ * @param dq                  Optional gradient query          [total_q, H, D] (fp16, output)
+ * @param dk                  Optional gradient key            [total_k, H, D] (fp16, output)
+ * @param dv                  Optional gradient value          [total_k, H, D] (fp16, output)
+ * @param cu_seqlens_q        Cumulative seq lengths for Q     [B+1] (int32, input)
+ * @param cu_seqlens_k        Cumulative seq lengths for K     [B+1] (int32, input)
+ * @param alibi_slopes        Optional ALiBi slopes tensor     (must match forward)
+ * @param max_seqlen_q        Maximum sequence length for Q    (int, input)
+ * @param max_seqlen_k        Maximum sequence length for K    (int, input)
+ * @param p_dropout           Dropout probability              (must match forward)
+ * @param softmax_scale       Softmax scale factor             (must match forward)
+ * @param zero_tensors        Zero grad tensors before compute (bool, input)
+ * @param is_causal           Causal masking flag              (must match forward)
+ * @param window_left         Left window size                 (must match forward)
+ * @param window_right        Right window size                (must match forward)
+ * @param softcap             Soft capping value               (must match forward)
+ * @param deterministic       Use deterministic backward pass  (bool, input)
+ * @param gen                 Optional RNG for dropout         (input)
+ * @param rng_state           Optional RNG state for repro     (input)
+ * @return                    Vector of gradient tensors {dq, dk, dv}
+ */
+std::vector<at::Tensor> flash_attention_varlen_backward(
+    const at::Tensor& dout,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& out,
+    const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq,
+    std::optional<at::Tensor>& dk,
+    std::optional<at::Tensor>& dv,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    std::optional<at::Tensor>& alibi_slopes,
+    const int    max_seqlen_q,
+    const int    max_seqlen_k,
+    const float  p_dropout,
+    const float  softmax_scale,
+    const bool   zero_tensors,
+    const bool   is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool  deterministic,
+    std::optional<at::Generator> gen,
+    std::optional<at::Tensor>& rng_state
+);

--- a/include/softmax.h
+++ b/include/softmax.h
@@ -11,7 +11,7 @@
 // ======================================================================================
 // WMMA_GEMM_SOFTMAX: Online softmax with O-scaling
 // ======================================================================================
-template<typename Config, int BLOCK_M, int BLOCK_N, int SCORE_STRIDE, int HEAD_STRIDE>
+template<typename Config, int BLOCK_M, int BLOCK_N, int SCORE_STRIDE, int HEAD_STRIDE, bool TILES = false>
 __device__ __forceinline__ void WMMA_GEMM_SOFTMAX(
     float*  __restrict__ SMEM_S,
     __half* __restrict__ SMEM_P,
@@ -40,14 +40,19 @@ __device__ __forceinline__ void WMMA_GEMM_SOFTMAX(
      __half* sP_half   = SMEM_P + row * SCORE_STRIDE;
     __half2* sP_half2  = reinterpret_cast<__half2*>(sP_half);
 
-    const int cols = VALID_KV >> 2;
-    const int tail = cols << 2;
+    const int cols =  VALID_KV >> 2;
+    const int tail = (VALID_KV >> 2) << 2;
 
     if (row < VALID_Q) {
         #pragma unroll 4
         for (int idx = thread; idx < cols; idx += THREADS_PER_ROW) {
             float4 buffer = sS_float4[idx];
             thread_max = fmaxf(thread_max, fmaxf(fmaxf(buffer.x, buffer.y), fmaxf(buffer.z, buffer.w)));
+        }
+        if constexpr (TILES) {
+            for (int idx = tail + thread; idx < VALID_KV; idx += THREADS_PER_ROW) {
+                thread_max = fmaxf(thread_max, sS_float[idx]);
+            }
         }
     }
 
@@ -75,13 +80,12 @@ __device__ __forceinline__ void WMMA_GEMM_SOFTMAX(
             half_buffer[rb_idx++] = __float22half2_rn(make_float2(e2, e3));
         }
 
-        if (tail < VALID_KV) {
-            #pragma unroll 4
-            for (int idx = tail + thread; idx < BLOCK_N; idx += THREADS_PER_ROW) {
-                float v = (idx < VALID_KV) ? sS_float[idx] : NEG_INF;
+        if constexpr (TILES) {
+            for (int idx = tail + thread; idx < VALID_KV; idx += THREADS_PER_ROW) {
+                float v = sS_float[idx];
                 float e = __expf(fmaxf(v - new_max, -80.0f));
-                thread_sum += (idx < VALID_KV) ? e : 0.0f;
-                sP_half[idx] = (idx < VALID_KV) ? __float2half_rn(e) : __float2half(0.f);
+                thread_sum += e;
+                sP_half[idx] = __float2half_rn(e);
             }
         }
 

--- a/include/template.h
+++ b/include/template.h
@@ -7,6 +7,10 @@
 
 // ======================================================================================
 // BlockInfo: Computes iteration bounds, offsets, and block for forward/backward kernels.
+//   - Forward/dQ: Grid Y = B * H_Q  -> BATCH_HEAD_ID decodes via H_Q
+//   - Backward dKV:
+//       * Varlen: Grid Y = B * H_Q  -> H_Q, maps to KV-head internally
+//       * Dense:  Grid Y = B * H_K  -> H_K directly
 // ======================================================================================
 template<bool IS_CAUSAL, bool IS_WINDOW, bool IS_VARLEN>
 struct BlockInfo {
@@ -49,32 +53,20 @@ struct BlockInfo {
         valid_kv_rows = 0;
 
         if constexpr (IS_VARLEN) {
-            head_idx    = BATCH_HEAD_ID;
+            batch_idx   = BATCH_HEAD_ID / H_Q;
+            head_idx    = BATCH_HEAD_ID % H_Q;
             kv_head_idx = head_idx / (H_Q / H_K);
-            batch_idx   = -1;
-            int local_block = BLOCK_IDX;
-            #pragma unroll 1
-            for (int b = 0; b < B; ++b) {
-                int seq_q = CU_SEQLENS_Q[b + 1] - CU_SEQLENS_Q[b];
-                int seq_k = CU_SEQLENS_K[b + 1] - CU_SEQLENS_K[b];
-                int blocks_in_seq = (seq_q + BLOCK_M - 1) / BLOCK_M;
-                if (local_block < blocks_in_seq) {
-                    batch_idx  = b;
-                    seqlen_q   = seq_q;
-                    seqlen_k   = seq_k;
-                    break;
-                }
-                local_block -= blocks_in_seq;
-            }
-            if (batch_idx == -1) { valid_q_rows = 0; return; }
+
+            q_base      = CU_SEQLENS_Q[batch_idx];
+            k_base      = CU_SEQLENS_K[batch_idx];
+            seqlen_q    = CU_SEQLENS_Q[batch_idx + 1] - q_base;
+            seqlen_k    = CU_SEQLENS_K[batch_idx + 1] - k_base;
 
             if (SEQUSED_K != nullptr) {
                 int used_k = SEQUSED_K[batch_idx];
                 seqlen_k = (used_k > 0) ? min(seqlen_k, used_k) : 0;
             }
-            q_base = CU_SEQLENS_Q[batch_idx];
-            k_base = CU_SEQLENS_K[batch_idx];
-            start_q = local_block * BLOCK_M;
+            start_q = BLOCK_IDX * BLOCK_M;
         } else {
             batch_idx   = BATCH_HEAD_ID / H_Q;
             head_idx    = BATCH_HEAD_ID % H_Q;
@@ -86,10 +78,15 @@ struct BlockInfo {
             start_q     = BLOCK_IDX * BLOCK_M;
         }
 
-        valid_q_rows    = min(BLOCK_M, seqlen_q - start_q);
-        seqlen_offset   = seqlen_k - seqlen_q;
-        block_min       = 0;
-        block_max       = (seqlen_k + BLOCK_N - 1) / BLOCK_N;
+        if (start_q >= seqlen_q) {
+            valid_q_rows = 0;
+            return;
+        }
+
+        valid_q_rows  = min(BLOCK_M, seqlen_q - start_q);
+        seqlen_offset = seqlen_k - seqlen_q;
+        block_min     = 0;
+        block_max     = (seqlen_k + BLOCK_N - 1) / BLOCK_N;
 
         // ==================================================================================
         // Trim K/V iteration range for causal and sliding window attention (forward/dQ phase)
@@ -134,32 +131,23 @@ struct BlockInfo {
         const int* CU_SEQLENS_K,
         const int* SEQUSED_K
     ) {
-        start_q      = 0;
-        valid_q_rows = 0;
+        start_q         = 0;
+        valid_q_rows    = 0;
 
         if constexpr (IS_VARLEN) {
-            kv_head_idx = BATCH_HEAD_ID;
-            head_idx    = -1;
-            batch_idx   = -1;
-            int local_block = BLOCK_IDX;
-            #pragma unroll 1
-            for (int b = 0; b < B; ++b) {
-                int seq_k = CU_SEQLENS_K[b + 1] - CU_SEQLENS_K[b];
-                int seq_q = CU_SEQLENS_Q[b + 1] - CU_SEQLENS_Q[b];
-                int blocks_in_seq = (seq_k + BLOCK_M - 1) / BLOCK_M;
-                if (local_block < blocks_in_seq) {
-                    batch_idx  = b;
-                    seqlen_k   = seq_k;
-                    seqlen_q   = seq_q;
-                    break;
-                }
-                local_block -= blocks_in_seq;
-            }
-            if (batch_idx == -1) { valid_kv_rows = 0; return; }
+            batch_idx   = BATCH_HEAD_ID / H_Q;
+            head_idx    = BATCH_HEAD_ID % H_Q;
+            kv_head_idx = head_idx / (H_Q / H_K);
+            q_base      = CU_SEQLENS_Q[batch_idx];
+            k_base      = CU_SEQLENS_K[batch_idx];
+            seqlen_q    = CU_SEQLENS_Q[batch_idx + 1] - q_base;
+            seqlen_k    = CU_SEQLENS_K[batch_idx + 1] - k_base;
 
-            q_base = CU_SEQLENS_Q[batch_idx];
-            k_base = CU_SEQLENS_K[batch_idx];
-            start_kv = local_block * BLOCK_M;
+            if (SEQUSED_K != nullptr) {
+                int used_k = SEQUSED_K[batch_idx];
+                seqlen_k = (used_k > 0) ? min(seqlen_k, used_k) : 0;
+            }
+            start_kv = BLOCK_IDX * BLOCK_M;
         } else {
             batch_idx   = BATCH_HEAD_ID / H_K;
             kv_head_idx = BATCH_HEAD_ID % H_K;
@@ -171,10 +159,15 @@ struct BlockInfo {
             start_kv    = BLOCK_IDX * BLOCK_M;
         }
 
-        valid_kv_rows   = min(BLOCK_M, seqlen_k - start_kv);
-        seqlen_offset   = seqlen_k - seqlen_q;
-        block_min       = 0;
-        block_max       = (seqlen_q + BLOCK_N - 1) / BLOCK_N;
+        if (start_kv >= seqlen_k) {
+            valid_kv_rows = 0;
+            return;
+        }
+
+        valid_kv_rows = min(BLOCK_M, seqlen_k - start_kv);
+        seqlen_offset = seqlen_k - seqlen_q;
+        block_min     = 0;
+        block_max     = (seqlen_q + BLOCK_N - 1) / BLOCK_N;
 
         // ==================================================================================
         // Trim Q-tile iteration range for causal and sliding window attention (dKV phase)

--- a/kernel/fused_mha_api.cpp
+++ b/kernel/fused_mha_api.cpp
@@ -16,4 +16,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("fwd", &flash_attention_forward,  "FlashAttention Forward Pass");
     m.def("bwd", &flash_attention_backward, "FlashAttention Backward Pass");
     m.def("varlen_fwd", &flash_attention_varlen_forward,  "FlashAttention Forward Pass  (variable length)");
+    m.def("varlen_bwd", &flash_attention_varlen_backward, "FlashAttention Backward Pass (variable length)");
 }

--- a/kernel/fused_mha_api.cpp
+++ b/kernel/fused_mha_api.cpp
@@ -12,7 +12,8 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "FlashAttention-2 implementation optimized for Volta";
-    m.def("fwd", &flash_attention_forward, "FlashAttention-2 Forward Pass (Volta)");
-    m.def("bwd", &flash_attention_backward, "FlashAttention-2 Backward Pass (Volta)");
+    m.doc() = "FlashAttention implementation optimized for Volta";
+    m.def("fwd", &flash_attention_forward,  "FlashAttention Forward Pass");
+    m.def("bwd", &flash_attention_backward, "FlashAttention Backward Pass");
+    m.def("varlen_fwd", &flash_attention_varlen_forward,  "FlashAttention Forward Pass  (variable length)");
 }

--- a/kernel/fused_mha_backward.cu
+++ b/kernel/fused_mha_backward.cu
@@ -511,6 +511,9 @@ void launcher_flash_attention_backward(
 ) {
     using Config = KernelConfig<D>;
 
+    const size_t smem = Config::TOTAL_SMEM;
+    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Backward kernel: ", smem, " bytes (", smem / 1024, " KB)");
+
     const int B   = Q.size(0);
     const int H_Q = Q.size(1);
     const int H_K = K.size(1);
@@ -523,40 +526,41 @@ void launcher_flash_attention_backward(
 
     const dim3 grid(grid_max, 2, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
-
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Backward kernel: ", smem, " bytes (", smem / 1024, " KB)");
 
     bool is_alibi   = (alibi_slopes != nullptr);
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
 
+    const __half* q_ptr   = reinterpret_cast<const __half*>(Q.data_ptr());
+    const __half* k_ptr   = reinterpret_cast<const __half*>(K.data_ptr());
+    const __half* v_ptr   = reinterpret_cast<const __half*>(V.data_ptr());
+    const __half* o_ptr   = reinterpret_cast<const __half*>(O.data_ptr());
+    const __half* dO_ptr  = reinterpret_cast<const __half*>(dO.data_ptr());
+    float*        lse_ptr = softmax_lse.data_ptr<float>();
+    __half*       dQ_ptr  = reinterpret_cast<__half*>(dQ.data_ptr());
+    __half*       dK_ptr  = reinterpret_cast<__half*>(dK.data_ptr());
+    __half*       dV_ptr  = reinterpret_cast<__half*>(dV.data_ptr());
+
     dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-        [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
-            constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
-            constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
-            constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
-            constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
-            constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+        constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
+        constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
+        constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
+        constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
+        constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
 
-            auto kernel = flash_attention_backward_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
-            cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        auto kernel = flash_attention_backward_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
 
-            kernel<<<grid, block, smem, stream>>>(
-                reinterpret_cast<const __half*>(Q.data_ptr()),
-                reinterpret_cast<const __half*>(K.data_ptr()),
-                reinterpret_cast<const __half*>(V.data_ptr()),
-                reinterpret_cast<const __half*>(O.data_ptr()),
-                reinterpret_cast<const __half*>(dO.data_ptr()),
-                softmax_lse.data_ptr<float>(),
-                reinterpret_cast<__half*>(dQ.data_ptr()),
-                reinterpret_cast<__half*>(dK.data_ptr()),
-                reinterpret_cast<__half*>(dV.data_ptr()),
-                B, H_Q, H_K, M, N, grid_dq, grid_dkv,
-                softmax_scale, softcap, alibi_slopes, window_left, window_right,
-                p_dropout, dropout_seed, dropout_offset);
-        });
+        kernel<<<grid, block, smem, stream>>>(
+            q_ptr, k_ptr, v_ptr, o_ptr, dO_ptr, lse_ptr,
+            dQ_ptr, dK_ptr, dV_ptr,
+            B, H_Q, H_K, M, N, grid_dq, grid_dkv,
+            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            p_dropout, dropout_seed, dropout_offset
+        );
+    });
 }
 
 // ======================================================================================
@@ -597,10 +601,11 @@ std::vector<at::Tensor> flash_attention_backward(
     TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
     TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
     TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "All tensors must be on CUDA");
-    TORCH_CHECK(out.is_cuda() && dout.is_cuda() && softmax_lse.is_cuda(), "All tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
-    TORCH_CHECK(out.stride(-1) == 1 && dout.stride(-1) == 1, "Last dim must be contiguous");
+
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(out.is_cuda() && dout.is_cuda() && softmax_lse.is_cuda(), "out, dout, softmax_lse must be on CUDA");
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
+    TORCH_CHECK(out.stride(-1) == 1 && dout.stride(-1) == 1, "Last dim of out, dout must be contiguous");
 
     // Variables
     const auto sizes = q.sizes();
@@ -612,22 +617,23 @@ std::vector<at::Tensor> flash_attention_backward(
     const int N      = k.size(2);
 
     TORCH_CHECK(B > 0, "batch_size must be positive");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be <=256 and a multiple of 8");
     TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
 
     // Window edge cases
     if (window_left  >= N) { window_left  = -1; }
     if (window_right >= N) { window_right = -1; }
 
-    // Alibi
+    // Alibi slopes validation
     const float* alibi = nullptr;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
         auto sizes = slopes.sizes();
-        TORCH_CHECK(slopes.dtype() == torch::kFloat32, "alibi_slopes must be fp32");
-        TORCH_CHECK(slopes.is_cuda(), "alibi_slopes must be on CUDA");
+        TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        TORCH_CHECK(slopes.sizes() == torch::IntArrayRef({H_Q}) || slopes.sizes() == torch::IntArrayRef({B, H_Q}), "alibi_slopes shape must be [H_Q] or [B, H_Q]");
+        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
         alibi = slopes.data_ptr<float>();
     }
 
@@ -638,7 +644,7 @@ std::vector<at::Tensor> flash_attention_backward(
     uint64_t dropout_seed   = 0;
     uint64_t dropout_offset = 0;
     if (p_dropout > 0.0f) {
-        TORCH_CHECK(rng_state.has_value() && rng_state->numel() == 2, "rng_state with 2 elements (seed, offset) is required when p_dropout > 0");
+        TORCH_CHECK(rng_state.has_value() && rng_state->numel() == 2, "rng_state required when p_dropout > 0");
         auto rng_cpu = rng_state->cpu();
         auto rng_acc = rng_cpu.accessor<int64_t, 1>();
         dropout_seed   = static_cast<uint64_t>(rng_acc[0]);
@@ -655,7 +661,7 @@ std::vector<at::Tensor> flash_attention_backward(
 
     auto dsoftmax_sum = torch::empty({B, H_Q, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    // Edge-case M == 0 or N == 0
+    // Edge-case early return
     if (M == 0 || N == 0) {
         dq_fp16.zero_();
         dk_fp16.zero_();

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -1,0 +1,776 @@
+// ======================================================================================
+// * Copyright (c) 2026, D.Skryabin / tg @ai_bond007 SPDX-License: BSD-3-Clause
+// ======================================================================================
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "debug.h"
+#include "template.h"
+#include "kernel.h"
+#include "backward.h"
+#include "gemm_smem.h"
+#include "product.h"
+#include "mat_mul.h"
+#include "softmax.h"
+
+// ======================================================================================
+// BACKWARD VARLEN KERNEL
+// ======================================================================================
+template<int D, bool IS_CAUSAL, bool IS_ALIBI, bool IS_SOFTCAP, bool IS_WINDOW, bool IS_DROPOUT>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+flash_attention_backward_varlen_kernel(
+    const __half* __restrict__ Q,
+    const __half* __restrict__ K,
+    const __half* __restrict__ V,
+    const __half* __restrict__ O,
+    const __half* __restrict__ dO,
+    const float*  __restrict__ softmax_lse,
+    __half* __restrict__ dQ,
+    __half* __restrict__ dK,
+    __half* __restrict__ dV,
+    float*  __restrict__ softmax_d,
+    const int* __restrict__ cu_seqlens_q,
+    const int* __restrict__ cu_seqlens_k,
+    const int      B,
+    const int      H_Q,
+    const int      H_K,
+    const int      T_Q,
+    const int      T_K,
+    const int      grid_dq,
+    const int      grid_dkv,
+    const float    softmax_scale,
+    const float    softcap,
+    const float*   alibi_slopes,
+    int            window_left,
+    int            window_right,
+    const float    p_dropout,
+    const uint64_t dropout_seed,
+    const uint64_t dropout_offset
+) {
+    // ======================================================================================
+    // PHASE 1: dQ (blockIdx.y == 0)
+    // ======================================================================================
+    if (blockIdx.y == 0) {
+        if (blockIdx.x >= grid_dq) return;
+
+        using Config = KernelConfig<D>;
+        constexpr int BLOCK_M   = Config::DQ::BLOCK_M;
+        constexpr int BLOCK_N   = Config::DQ::BLOCK_N;
+        constexpr int D_STRIDE  = Config::DQ::D_STRIDE;
+        constexpr int N_STRIDE  = Config::DQ::N_STRIDE;
+
+        // ======================================================================================
+        // Grid Mapping: 1D X for Q-blocks, Z for heads. Batch resolved device-side.
+        // ======================================================================================
+        const int block_idx    = blockIdx.x;
+        const int bthd_idx     = blockIdx.z;
+        if (bthd_idx >= H_Q) return;
+
+        // ======================================================================================
+        // BlockInfo: Metadata resolution
+        // ======================================================================================
+        BlockInfo<IS_CAUSAL, IS_WINDOW, true> block;
+        block.init_q(
+            block_idx,       // BLOCK_IDX:      Current Q-block index (grid.x)
+            bthd_idx,        // BATCH_HEAD_ID:  Batch head index
+            H_Q,             // H_Q:            Number of query heads
+            H_K,             // H_K:            Number of KV heads
+            0,               // M:              (unused for varlen)
+            0,               // N:              (unused for varlen)
+            B,               // B:              B (batch size for device-side loop)
+            BLOCK_M,         // BLOCK_M:        Tile size along Q dimension
+            BLOCK_N,         // BLOCK_N:        Tile size along KV dimension
+            window_left,     // WINDOW_LEFT:    Left sliding window bound (-1 if disabled)
+            window_right,    // WINDOW_RIGHT:   Right sliding window bound (-1 if disabled)
+            cu_seqlens_q,    // CU_SEQLENS_Q:   Cumulative Q lengths
+            cu_seqlens_k,    // CU_SEQLENS_K:   Cumulative KV lengths
+            nullptr          // SEQUSED_K:      (not used in backward)
+        );
+
+        if (block.start_q >= block.seqlen_q || block.valid_q_rows <= 0) return;
+
+        // ======================================================================================
+        // EARLY EXIT: No valid KV blocks to attend to (Causal/Window/Empty KV)
+        // Writes deterministic zeros to dQ and softmax_d for numerical stability.
+        // ======================================================================================
+        if (block.block_min >= block.block_max || block.seqlen_k == 0) {
+            const size_t dq_base   = block.q_offset(D, H_Q, T_Q);
+            const size_t dlse_base = block.lse_offset(H_Q, T_Q);
+            for (int row = threadIdx.x; row < block.valid_q_rows; row += blockDim.x) {
+                #pragma unroll
+                for (int d = 0; d < D; ++d) {
+                    dQ[dq_base + row * H_Q * D + d] = __float2half(0.0f);
+                }
+                softmax_d[dlse_base + row] = 0.0f;
+            }
+            return;
+        }
+
+        // ======================================================================================
+        // Init:   thread/warp/lane IDs for WMMA coordination
+        // ======================================================================================
+        const int tid     = threadIdx.x;
+        const int warp_id = tid >> 5;
+        const int lane_id = tid & 31;
+
+        // Alibi slope for current head
+        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
+
+        // ======================================================================================
+        // RAGGED POINTERS
+        // Layout:
+        //   Q/O/dO/dQ: [T_Q, H_Q, D]            offset follows q_base + start_q (Q, H_Q, D)
+        //   K/V:       [T_K, H_K, D]            offset follows k_base (K, H_K, D)
+        //   LSE/dLSE:  [H_Q, T_Q]               offset follows bthd_idx * T_Q (H_Q, T_Q)
+        // ======================================================================================
+        const __half* __restrict__ q_ptr   = Q  + block.q_offset(D, H_Q, T_Q);
+        const __half* __restrict__ k_ptr   = K  + block.kv_offset(D, H_K, T_K);
+        const __half* __restrict__ v_ptr   = V  + block.kv_offset(D, H_K, T_K);
+        const __half* __restrict__ o_ptr   = O  + block.q_offset(D, H_Q, T_Q);
+        const __half* __restrict__ dO_ptr  = dO + block.q_offset(D, H_Q, T_Q);
+        __half* __restrict__ dQ_ptr        = dQ + block.q_offset(D, H_Q, T_Q);
+        const float*  __restrict__ lse_ptr = softmax_lse + block.lse_offset(H_Q, T_Q);
+        float*  __restrict__ dLse_ptr      = softmax_d   + block.lse_offset(H_Q, T_Q);
+
+        // ======================================================================================
+        // INIT SHARED MEMORY
+        // ======================================================================================
+        extern __shared__ char smem_raw[];
+        WMMA_GEMM_INIT_SMEM<Config>(smem_raw);
+        __syncthreads();
+        auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+        __half* __restrict__ sQ      = smem.phase.bdq.q;
+        __half* __restrict__ sK      = smem.phase.bdq.reuse_kv.k;
+        __half* __restrict__ sV      = smem.phase.bdq.reuse_kv.v;
+        float*  __restrict__ sS      = smem.phase.bdq.s;
+        __half* __restrict__ sdO     = smem.phase.bdq.dO;
+        float*  __restrict__ sdOV    = smem.phase.bdq.reuse_sdOVS.dOV;
+        __half* __restrict__ sdS     = smem.phase.bdq.reuse_sdOVS.dS;
+        float*  __restrict__ sRowDot = smem.row_dot;
+        float*  __restrict__ sLse    = smem.lse;
+        float*  __restrict__ sdQ     = smem.phase.bdq.dQ;
+
+        // ======================================================================================
+        // Load:     Q & dO tiles from global to sQ/sdO shared memory
+        // Layout:   Q:  global[row: BLOCK_M, H_Q * D] -> shared[row: BLOCK_M, D_STRIDE]
+        //           dO: global[row: BLOCK_M, H_Q * D] -> shared[row: BLOCK_M, D_STRIDE]
+        // Template: DUAL_LOAD=true, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, true, D_STRIDE, D>(
+          q_ptr,   sQ,
+          dO_ptr,  sdO,
+          H_Q * D, block.valid_q_rows, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  row_dot = sum(O ⊙ dO) element-wise
+        // Layout:   o_ptr[valid_q_rows, H_Q * D] ⊙ sdO[valid_q_rows, D_STRIDE] -> sRowDot[valid_q_rows]
+        // Template: D_STRIDE=D_STRIDE, HEAD_STRIDE=D_STRIDE
+        // ======================================================================================
+        WMMA_GEMM_DOT_PRODUCT<Config, GemmType::rowdot_dQ, D_STRIDE>(
+          o_ptr, sdO, lse_ptr, sLse, sRowDot,
+          D, block.valid_q_rows, 0, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // MAIN LOOP (Iterates over logical KV blocks)
+        // ======================================================================================
+        for (int block_q = block.block_min; block_q < block.block_max; ++block_q) {
+            const int start_kv      = block_q * BLOCK_N;
+            const int valid_kv_rows = min(BLOCK_N, block.seqlen_k - start_kv);
+            if (valid_kv_rows <= 0) break;
+
+            // ======================================================================================
+            // Load:     V tile from global to sV shared memory
+            // Layout:   V: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+            // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+            // ======================================================================================
+            WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+              v_ptr + start_kv * H_K * D, sV,
+              nullptr,                    nullptr,
+              H_K * D, valid_kv_rows, tid);
+            __syncthreads();
+
+            // ======================================================================================
+            // Compute:  dOV = dO @ V^T
+            // Layout:   sdO[valid_q_rows, D_STRIDE] @ sV^T -> sdOV[valid_q_rows, N_STRIDE]
+            // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+            // ======================================================================================
+            WMMA_GEMM_SCORES<Config, GemmType::dOV_dOVT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_M, BLOCK_N, D_STRIDE, N_STRIDE>(
+              sdO, sV, sdOV,
+              block.valid_q_rows,  valid_kv_rows,
+              0,                   0,
+              0,
+              1.0f, 0.0f, 0.0f, -1, -1,
+              warp_id, lane_id);
+            __syncthreads();
+
+            // ======================================================================================
+            // Load:     K tile from global to sK shared memory
+            // Layout:   K: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+            // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+            // ======================================================================================
+            WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+              k_ptr + start_kv * H_K * D, sK,
+              nullptr,                    nullptr,
+              H_K * D, valid_kv_rows, tid);
+            __syncthreads();
+
+            // ======================================================================================
+            // Compute:  S = Q @ K^T
+            // Layout:   sQ[valid_q_rows, D_STRIDE] @ sK^T -> sS[valid_q_rows, N_STRIDE]
+            // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+            // ======================================================================================
+            WMMA_GEMM_SCORES<Config, GemmType::sQ_KT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_M, BLOCK_N, D_STRIDE, N_STRIDE>(
+              sQ, sK, sS,
+              block.valid_q_rows,  valid_kv_rows,
+              block.start_q,       start_kv,
+              block.seqlen_offset,
+              softmax_scale, softcap, alibi_slope, window_left, window_right,
+              warp_id, lane_id);
+            __syncthreads();
+
+            // ======================================================================================
+            // Compute:  dS = exp(S - lse) * (dOV - row_dot) * softmax_scale
+            // Layout:   sS[valid_q_rows, N_STRIDE], sdOV[valid_q_rows, N_STRIDE]
+            //           -> sdS[valid_q_rows, N_STRIDE]
+            // Varlen:   GLOBAL_N=block.seqlen_k (actual KV length) for correct dropout RNG stride
+            // Template: IS_DROPOUT guards compile-time; runtime p_dropout > 0 enables execution
+            // ======================================================================================
+            WMMA_GEMM_SOFTMAX_GRADIENT<Config, GemmType::compute_dS, IS_SOFTCAP, IS_DROPOUT, N_STRIDE, N_STRIDE, BLOCK_M, BLOCK_N>(
+              sS, sdOV, sLse, sRowDot, nullptr, sdS,
+              block.valid_q_rows, valid_kv_rows,
+              softmax_scale, softcap,
+              p_dropout, dropout_seed, dropout_offset,
+              block.q_base + block.start_q, start_kv, block.seqlen_k,
+              tid);
+            __syncthreads();
+
+            // ======================================================================================
+            // Compute:  dQ += dS @ K
+            // Layout:   sdS[valid_q_rows, N_STRIDE] @ sK[valid_kv_rows, D_STRIDE] += sdQ
+            // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+            // ======================================================================================
+            WMMA_GEMM_GRADIENTS<Config, GemmType::dQ_dSK, D, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE>(
+              sdS, sK, sdQ,
+              block.valid_q_rows, valid_kv_rows,
+              warp_id, lane_id);
+            __syncthreads();
+        }   // END MAIN LOOP
+        // ======================================================================================
+        // Compute:  Store dQ and dLSE to global memory
+        // Layout:   sdQ[row: valid_q_rows, D_STRIDE] -> dQ_ptr[row: valid_q_rows, H_Q * D]
+        //           sRowDot[valid_q_rows] -> softmax_d_ptr[valid_q_rows]
+        // Template: SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile store)
+        // ======================================================================================
+        WMMA_GEMM_EPILOGUE<Config, GemmType::write_dQ, D_STRIDE, D>(
+          sdQ,     dQ_ptr,
+          nullptr, nullptr,
+          nullptr, H_Q * D, block.valid_q_rows, tid);
+
+        if (tid < block.valid_q_rows) {
+            dLse_ptr[tid] = sRowDot[tid];
+        }
+    }
+    // ======================================================================================
+    // PHASE 2: dKV computation (blockIdx.y == 1)
+    // ======================================================================================
+    else if (blockIdx.y == 1) {
+        if (blockIdx.x >= grid_dkv) return;
+
+        using Config = KernelConfig<D>;
+        constexpr int BLOCK_M   = Config::DKV::BLOCK_M;
+        constexpr int BLOCK_N   = Config::DKV::BLOCK_N;
+        constexpr int D_STRIDE  = Config::DKV::D_STRIDE;
+        constexpr int M_STRIDE  = Config::DKV::M_STRIDE;
+
+        // ======================================================================================
+        // Grid Mapping: 1D X for KV-blocks, Z for bthd_idx. Batch resolved device-side.
+        // ======================================================================================
+        const int block_idx    = blockIdx.x;
+        const int bthd_idx  = blockIdx.z;
+        if (bthd_idx >= H_K) return;
+
+        // ======================================================================================
+        // BlockInfo: Metadata resolution
+        // ======================================================================================
+        BlockInfo<IS_CAUSAL, IS_WINDOW, true> block;
+        block.init_kv(
+            block_idx,       // BLOCK_IDX:      Current KV-block index (grid.x)
+            bthd_idx,        // BATCH_HEAD_ID:  Batch head index (KV head)
+            H_Q,             // H_Q:            Number of query heads
+            H_K,             // H_K:            Number of KV heads
+            0,               // M:              (unused for varlen)
+            0,               // N:              (unused for varlen)
+            B,               // B:              B (batch size for device-side loop)
+            BLOCK_M,         // BLOCK_M:        Tile size along KV dimension
+            BLOCK_N,         // BLOCK_N:        Tile size along Q dimension
+            window_left,     // WINDOW_LEFT:    Left sliding window bound (-1 if disabled)
+            window_right,    // WINDOW_RIGHT:   Right sliding window bound (-1 if disabled)
+            cu_seqlens_q,    // CU_SEQLENS_Q:   Cumulative Q lengths
+            cu_seqlens_k,    // CU_SEQLENS_K:   Cumulative KV lengths
+            nullptr          // SEQUSED_K:      (not used in backward)
+        );
+
+        if (block.start_kv >= block.seqlen_k || block.valid_kv_rows <= 0) return;
+
+        // ======================================================================================
+        // EARLY EXIT: No valid Q blocks attend to this KV block.
+        // Writes deterministic zeros to dK and dV for ALL mapped Q-heads (GQA/MQA safe).
+        // ======================================================================================
+        if (block.block_min >= block.block_max || block.seqlen_q == 0) {
+            for (int group = 0; group < (H_Q / H_K); ++group) {
+                const int q_head = block.kv_head_idx * (H_Q / H_K) + group;
+                const size_t dk_base = static_cast<size_t>(block.k_base + block.start_kv) * H_Q * D + static_cast<size_t>(q_head) * D;
+                const size_t dv_base = static_cast<size_t>(block.k_base + block.start_kv) * H_Q * D + static_cast<size_t>(q_head) * D;
+                for (int row = threadIdx.x; row < block.valid_kv_rows; row += blockDim.x) {
+                    #pragma unroll
+                    for (int d = 0; d < D; ++d) {
+                        dK[dk_base + row * H_Q * D + d] = __float2half(0.0f);
+                        dV[dv_base + row * H_Q * D + d] = __float2half(0.0f);
+                    }
+                }
+            }
+            return;
+        }
+
+        // ======================================================================================
+        // Init:   thread/warp/lane IDs for WMMA coordination
+        // ======================================================================================
+        const int tid     = threadIdx.x;
+        const int warp_id = tid >> 5;
+        const int lane_id = tid & 31;
+
+        // ======================================================================================
+        // RAGGED POINTERS (Base for KV)
+        // Layout:
+        //   K/V:       [T_K, H_K, D]            offset follows k_base (K, H_K, D)
+        //   dK/dV:     [T_K, H_Q, D] expanded   offset follows k_base + start_kv (KV, H_Q, D)
+        // ======================================================================================
+        const __half* __restrict__ k_ptr  = K  + block.kv_offset(D, H_K, T_K);
+        const __half* __restrict__ v_ptr  = V  + block.kv_offset(D, H_K, T_K);
+        __half* __restrict__ dK_ptr_base  = dK + static_cast<size_t>(block.k_base + block.start_kv) * H_Q * D;
+        __half* __restrict__ dV_ptr_base  = dV + static_cast<size_t>(block.k_base + block.start_kv) * H_Q * D;
+
+        // ======================================================================================
+        // INIT SHARED MEMORY
+        // ======================================================================================
+        extern __shared__ char smem_raw[];
+
+        WMMA_GEMM_INIT_SMEM<Config>(smem_raw);
+
+        __syncthreads();
+
+        auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+        __half* __restrict__ sQ      = smem.phase.bdkv.reuse_qdO.q;
+        __half* __restrict__ sK      = smem.phase.bdkv.k;
+        __half* __restrict__ sV      = smem.phase.bdkv.v;
+        float*  __restrict__ sS      = smem.phase.bdkv.reuse_sp.s;
+        __half* __restrict__ sdO     = smem.phase.bdkv.reuse_qdO.dO;
+        float*  __restrict__ sdOV    = smem.phase.bdkv.reuse_dOVS.dOV;
+        __half* __restrict__ sdS     = smem.phase.bdkv.reuse_dOVS.dS;
+        __half* __restrict__ sP      = smem.phase.bdkv.reuse_sp.p;
+        float*  __restrict__ sRowDot = smem.row_dot;
+        float*  __restrict__ sLse    = smem.lse;
+        float*  __restrict__ sdK     = smem.phase.bdkv.dK;
+        float*  __restrict__ sdV     = smem.phase.bdkv.dV;
+
+        // ======================================================================================
+        // Load:     K & V tiles from global to sK/sV shared memory
+        // Layout:   K: global[row: BLOCK_M, H_K * D] -> shared[row: BLOCK_M, D_STRIDE]
+        //           V: global[row: BLOCK_M, H_K * D] -> shared[row: BLOCK_M, D_STRIDE]
+        // Template: DUAL_LOAD=true, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, true, D_STRIDE, D>(
+          k_ptr + block.start_kv * H_K * D, sK,
+          v_ptr + block.start_kv * H_K * D, sV,
+          H_K * D, block.valid_kv_rows, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // Q-HEADS LOOP (GQA/MQA Expansion)
+        // Iterates over all Q-heads that map to the current KV-head
+        // ======================================================================================
+        for (int group = 0; group < (H_Q / H_K); ++group) {
+            const int bthd_idx = block.kv_head_idx * (H_Q / H_K) + group;
+            const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
+
+            // ======================================================================================
+            // RAGGED POINTERS for current Q-head
+            // Layout:
+            //   Q/O/dO:    [T_Q, H_Q, D]   offset follows q_base + bthd_idx * D
+            //   LSE:       [H_Q, T_Q]       offset follows bthd_idx * T_Q + q_base
+            //   dK/dV:     [T_K, H_Q, D]    offset follows k_base + start_kv + bthd_idx * D
+            // ======================================================================================
+            const size_t q_head_off = static_cast<size_t>(block.q_base) * H_Q * D + static_cast<size_t>(bthd_idx) * D;
+            const __half* __restrict__ q_ptr   = Q  + q_head_off;
+            const __half* __restrict__ o_ptr   = O  + q_head_off;
+            const __half* __restrict__ dO_ptr  = dO + q_head_off;
+            const float*  __restrict__ lse_ptr = softmax_lse + static_cast<size_t>(bthd_idx) * T_Q + block.q_base;
+
+            __half* __restrict__ dK_ptr = dK_ptr_base + static_cast<size_t>(bthd_idx) * D;
+            __half* __restrict__ dV_ptr = dV_ptr_base + static_cast<size_t>(bthd_idx) * D;
+
+            // ======================================================================================
+            // Q-HEADS LOOP (Iterate over Q-head groups sharing this KV-head)
+            // ======================================================================================
+            for (int block_q = block.block_min; block_q < block.block_max; ++block_q) {
+                const int start_q      = block_q * BLOCK_N;
+                const int valid_q_rows = min(BLOCK_N, block.seqlen_q - start_q);
+                if (valid_q_rows <= 0) break;
+
+                // ======================================================================================
+                // Load:     Q tile from global to sQ shared memory
+                // Layout:   Q: global[row: BLOCK_N, H_Q * D] -> shared[row: BLOCK_N, D_STRIDE]
+                // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+                // ======================================================================================
+                WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+                  q_ptr + start_q * H_Q * D, sQ,
+                  nullptr,                   nullptr,
+                  H_Q * D, valid_q_rows, tid);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  S = Q @ K^T
+                // Layout:   sQ[valid_q_rows, D_STRIDE] @ sK^T -> sS[valid_q_rows, M_STRIDE]
+                // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+                // Note:     M/N swapped for dKV phase (transposed layout)
+                // ======================================================================================
+                WMMA_GEMM_SCORES<Config, GemmType::sQ_KT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_N, BLOCK_M, D_STRIDE, M_STRIDE>(
+                  sQ, sK, sS,
+                  valid_q_rows,          block.valid_kv_rows,
+                  start_q,               block.start_kv,
+                  block.seqlen_offset,
+                  softmax_scale, softcap, alibi_slope, window_left, window_right,
+                  warp_id, lane_id);
+                __syncthreads();
+
+                // ======================================================================================
+                // Load:     dO tile from global to sdO shared memory
+                // Layout:   dO: global[row: BLOCK_N, H_Q * D] -> shared[row: BLOCK_N, D_STRIDE]
+                // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+                // ======================================================================================
+                WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+                  dO_ptr + start_q * H_Q * D, sdO,
+                  nullptr,                    nullptr,
+                  H_Q * D, valid_q_rows, tid);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  row_dot = sum(O ⊙ dO) element-wise
+                // Layout:   o_ptr[start_q:valid_q_rows, H_Q * D] ⊙ sdO -> sRowDot[valid_q_rows]
+                // Template: D_STRIDE=D_STRIDE
+                // ======================================================================================
+                WMMA_GEMM_DOT_PRODUCT<Config, GemmType::rowdot_dKV, D_STRIDE>(
+                  o_ptr + start_q * H_Q * D, sdO, lse_ptr, sLse, sRowDot,
+                  D, valid_q_rows, start_q, tid);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  dOV = dO @ V^T
+                // Layout:   sdO[valid_q_rows, D_STRIDE] @ sV^T -> sdOV[valid_q_rows, M_STRIDE]
+                // Template: BLOCK_N/BLOCK_M static, valid_q/valid_kv dynamic (varlen ragged tiles)
+                // Note:     M/N swapped for dKV phase (transposed layout)
+                // ======================================================================================
+                WMMA_GEMM_SCORES<Config, GemmType::dOV_dOVT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_N, BLOCK_M, D_STRIDE, M_STRIDE>(
+                  sdO, sV, sdOV,
+                  valid_q_rows,          block.valid_kv_rows,
+                  0,                     0,
+                  0,
+                  1.0f, 0.0f, 0.0f, -1, -1,
+                  warp_id, lane_id);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  P = softmax(S), dS = P * (dOV - row_dot) * softmax_scale
+                // Layout:   sS[valid_q_rows, M_STRIDE] -> sP[valid_q_rows, M_STRIDE]
+                //           sdS[valid_q_rows, M_STRIDE]
+                // Varlen:   GLOBAL_N=block.seqlen_k for correct dropout RNG stride
+                // Template: IS_DROPOUT guards compile-time; runtime p_dropout > 0 enables execution
+                // ======================================================================================
+                WMMA_GEMM_SOFTMAX_GRADIENT<Config, GemmType::compute_P_dS, IS_SOFTCAP, IS_DROPOUT, M_STRIDE, BLOCK_M, BLOCK_N, BLOCK_M>(
+                  sS, sdOV, sLse, sRowDot, sP, sdS,
+                  valid_q_rows, block.valid_kv_rows,
+                  softmax_scale, softcap,
+                  p_dropout, dropout_seed, dropout_offset,
+                  block.q_base + start_q, block.start_kv, block.seqlen_k,
+                  tid);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  dV += P^T @ dO
+                // Layout:   sP^T[valid_kv_rows, M_STRIDE] @ sdO[valid_q_rows, D_STRIDE] += sdV
+                // Template: BLOCK_M/BLOCK_N static, valid_kv/valid_q dynamic (varlen ragged tiles)
+                // ======================================================================================
+                WMMA_GEMM_GRADIENTS<Config, GemmType::dV_PTdO, D, BLOCK_M, BLOCK_N, BLOCK_M, D_STRIDE>(
+                  sP, sdO, sdV,
+                  block.valid_kv_rows, valid_q_rows,
+                  warp_id, lane_id);
+                __syncthreads();
+
+                // ======================================================================================
+                // Compute:  dK += dS^T @ Q
+                // Layout:   sdS^T[valid_kv_rows, M_STRIDE] @ sQ[valid_q_rows, D_STRIDE] += sdK
+                // Template: BLOCK_M/BLOCK_N static, valid_kv/valid_q dynamic (varlen ragged tiles)
+                // ======================================================================================
+                WMMA_GEMM_GRADIENTS<Config, GemmType::dK_dSTQ, D, BLOCK_M, BLOCK_N, BLOCK_M, D_STRIDE>(
+                  sdS, sQ, sdK,
+                  block.valid_kv_rows, valid_q_rows,
+                  warp_id, lane_id);
+                __syncthreads();
+            } // END Q-TILES LOOP
+            // ======================================================================================
+            // Compute:  Store dK & dV for current Q-head to global memory (Expanded Layout)
+            // Layout:   sdK[row: valid_kv_rows, D_STRIDE] -> dK_ptr[row: valid_kv_rows, H_Q * D]
+            //           sdV[row: valid_kv_rows, D_STRIDE] -> dV_ptr[row: valid_kv_rows, H_Q * D]
+            // Template: DUAL_STORE=true, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile store)
+            // ======================================================================================
+            WMMA_GEMM_EPILOGUE<Config, GemmType::write_dKV, D_STRIDE, D>(
+              sdK,     dK_ptr,
+              sdV,     dV_ptr,
+              nullptr, H_Q * D, block.valid_kv_rows, tid);
+        } // END Q-HEADS LOOP
+    }
+}
+
+// ======================================================================================
+// LAUNCHER
+// ======================================================================================
+template<int D>
+void launcher_flash_attention_backward_varlen(
+    const torch::Tensor& Q,
+    const torch::Tensor& K,
+    const torch::Tensor& V,
+    const torch::Tensor& O,
+    const torch::Tensor& dO,
+    const torch::Tensor& softmax_lse,
+          torch::Tensor& dQ,
+          torch::Tensor& dK,
+          torch::Tensor& dV,
+          torch::Tensor& softmax_d,
+    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_k,
+    const int    T_Q,
+    const int    T_K,
+    const int    max_seqlen_q,
+    const int    max_seqlen_k,
+    float        softmax_scale,
+    bool         is_causal,
+    float        softcap,
+    float        p_dropout,
+    const float* alibi_slopes,
+    int          window_left,
+    int          window_right,
+    uint64_t     dropout_seed,
+    uint64_t     dropout_offset,
+    cudaStream_t stream
+) {
+    using Config = KernelConfig<D>;
+
+    const size_t smem = Config::TOTAL_SMEM;
+    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Backward varlen kernel: ", smem, " bytes (", smem / 1024, " KB)");
+
+    const int B   = cu_seqlens_q.size(0) - 1;
+    const int H_Q = Q.size(1);
+    const int H_K = K.size(1);
+
+    const int grid_dq  = (max_seqlen_q + Config::DQ::BLOCK_M  - 1) / Config::DQ::BLOCK_M;
+    const int grid_dkv = (max_seqlen_k + Config::DKV::BLOCK_M - 1) / Config::DKV::BLOCK_M;
+    const int grid_x   = max(grid_dq, grid_dkv);
+    const dim3 grid(grid_x, 2, B * H_Q);
+    const dim3 block(Config::THREADS_PER_BLOCK);
+
+    bool is_alibi   = (alibi_slopes != nullptr);
+    bool is_softcap = (softcap > 0.0f);
+    bool is_window  = (window_left >= 0 || window_right >= 0);
+    bool is_dropout = (p_dropout > 0.0f);
+
+    const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
+    const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
+    const __half* v_ptr            = reinterpret_cast<const __half*>(V.data_ptr());
+    const __half* o_ptr            = reinterpret_cast<const __half*>(O.data_ptr());
+    const __half* dO_ptr           = reinterpret_cast<const __half*>(dO.data_ptr());
+    float*        lse_ptr          = softmax_lse.data_ptr<float>();
+    __half*       dq_ptr           = reinterpret_cast<__half*>(dQ.data_ptr());
+    __half*       dk_ptr           = reinterpret_cast<__half*>(dK.data_ptr());
+    __half*       dv_ptr           = reinterpret_cast<__half*>(dV.data_ptr());
+    float*        softmax_d_ptr    = softmax_d.data_ptr<float>();
+    const int*    cu_seqlens_q_ptr = cu_seqlens_q.data_ptr<int>();
+    const int*    cu_seqlens_k_ptr = cu_seqlens_k.data_ptr<int>();
+
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+        constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
+        constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
+        constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
+        constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
+        constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
+
+        auto kernel = flash_attention_backward_varlen_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+
+        kernel<<<grid, block, smem, stream>>>(
+            q_ptr, k_ptr, v_ptr, o_ptr, dO_ptr, lse_ptr,
+            dq_ptr, dk_ptr, dv_ptr, softmax_d_ptr,
+            cu_seqlens_q_ptr, cu_seqlens_k_ptr,
+            B, H_Q, H_K, T_Q, T_K, grid_dq, grid_dkv,
+            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            p_dropout, dropout_seed, dropout_offset
+        );
+    });
+}
+
+// ======================================================================================
+// WRAPPER
+// ======================================================================================
+std::vector<at::Tensor> flash_attention_varlen_backward(
+    const at::Tensor& dout,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    const at::Tensor& out,
+    const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq,
+    std::optional<at::Tensor>& dk,
+    std::optional<at::Tensor>& dv,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    std::optional<at::Tensor>& alibi_slopes,
+    const int   max_seqlen_q,
+    const int   max_seqlen_k,
+    const float p_dropout,
+    const float softmax_scale,
+    const bool  zero_tensors,
+    const bool  is_causal,
+    int         window_left,
+    int         window_right,
+    const float softcap,
+    const bool  deterministic,
+    std::optional<at::Generator> gen,
+    std::optional<at::Tensor>& rng_state
+) {
+    // Device guard for multi-GPU / pipeline-parallelism
+    at::cuda::CUDAGuard device_guard{q.device()};
+
+    auto props = at::cuda::getCurrentDeviceProperties();
+    TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
+    TORCH_CHECK(!deterministic, "Deterministic backward not supported in this Volta build");
+
+    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
+    TORCH_CHECK(out.stride(-1) == 1 && dout.stride(-1) == 1, "Last dim of out, dout must be contiguous");
+
+    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32 && cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens must be int32");
+    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA device");
+    TORCH_CHECK(cu_seqlens_q.is_contiguous() && cu_seqlens_k.is_contiguous(), "cu_seqlens must be contiguous");
+    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D tensors");
+
+    const int T_Q   = q.size(0);
+    const int H_Q   = q.size(1);
+    const int D     = q.size(2);
+    const int T_K   = k.size(0);
+    const int H_K   = k.size(1);
+    const int B     = cu_seqlens_q.size(0) - 1;
+
+    TORCH_CHECK(B > 0, "batch_size must be positive");
+    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
+
+    // Window edge cases
+    if (window_left  >= max_seqlen_k) window_left  = -1;
+    if (window_right >= max_seqlen_k) window_right = -1;
+
+    // Alibi
+    const float* alibi = nullptr;
+    if (alibi_slopes.has_value()) {
+        const auto& slopes = alibi_slopes.value();
+        auto sizes = slopes.sizes();
+        TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
+        TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
+        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi = slopes.data_ptr<float>();
+    }
+
+    // Dropout
+    TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
+
+    uint64_t dropout_seed   = 0;
+    uint64_t dropout_offset = 0;
+    if (p_dropout > 0.0f) {
+        TORCH_CHECK(rng_state.has_value() && rng_state->numel() == 2, "rng_state required when p_dropout > 0");
+        auto rng_cpu = rng_state->cpu();
+        auto rng_acc = rng_cpu.accessor<int64_t, 1>();
+        dropout_seed   = static_cast<uint64_t>(rng_acc[0]);
+        dropout_offset = static_cast<uint64_t>(rng_acc[1]);
+    }
+
+    // Output tensors
+    at::Tensor dq_fp16 = dq.has_value() ? dq.value() : torch::empty_like(q);
+    at::Tensor dk_fp16 = dk.has_value() ? dk.value() : torch::empty_like(k);
+    at::Tensor dv_fp16 = dv.has_value() ? dv.value() : torch::empty_like(v);
+
+    // GQA/MQA expansion buffers [T_K, H_Q, D] for deterministic host-side reduction
+    at::Tensor dk_expanded = (H_K != H_Q) ? torch::empty({T_K, H_Q, D}, q.options()) : dk_fp16;
+    at::Tensor dv_expanded = (H_K != H_Q) ? torch::empty({T_K, H_Q, D}, q.options()) : dv_fp16;
+
+    // dLSE tensor matches forward LSE layout [H_Q, T_Q]
+    auto softmax_d = torch::empty({H_Q, T_Q}, torch::dtype(torch::kFloat32).device(q.device()));
+
+    // Edge-case return
+    if (zero_tensors) {
+        dq_fp16.zero_();
+        dk_expanded.zero_();
+        dv_expanded.zero_();
+        softmax_d.zero_();
+    }
+
+    if (T_Q == 0 || max_seqlen_k == 0) {
+        return {dq_fp16, dk_fp16, dv_fp16, softmax_d};
+    }
+
+    // Run kernel
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    #define LAUNCH_KERNEL(DIM) \
+        launcher_flash_attention_backward_varlen<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_expanded, dv_expanded, softmax_d, \
+            cu_seqlens_q, cu_seqlens_k, T_Q, T_K, max_seqlen_q, max_seqlen_k, \
+            softmax_scale, is_causal, softcap, p_dropout, alibi, \
+            window_left, window_right, dropout_seed, dropout_offset, stream);
+
+    switch (D) {
+        case 16:  LAUNCH_KERNEL(16);  break;
+        case 32:  LAUNCH_KERNEL(32);  break;
+        case 64:  LAUNCH_KERNEL(64);  break;
+        case 128: LAUNCH_KERNEL(128); break;
+        case 256: LAUNCH_KERNEL(256); break;
+        default: TORCH_CHECK(false, "Unsupported D: ", D);
+    }
+    #undef LAUNCH_KERNEL
+
+    // Reduce expanded gradients for GQA/MQA
+    if (H_K != H_Q) {
+        at::sum_out(dk_fp16, at::reshape(dk_expanded, {T_K, H_K, H_Q / H_K, D}), {2});
+        at::sum_out(dv_fp16, at::reshape(dv_expanded, {T_K, H_K, H_Q / H_K, D}), {2});
+    }
+
+    return {dq_fp16, dk_fp16, dv_fp16, softmax_d};
+}

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -175,7 +175,7 @@ flash_attention_forward_kernel(
         // ==================================================================================
         // Compute:  Online Softmax + O-scaling
         // Layout:   S[BLOCK_M, BLOCK_N] -> P[BLOCK_M, BLOCK_N], O[BLOCK_M, D] scaled
-        // Template: BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE, TAILS(FALSE)
+        // Template: BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE
         // ==================================================================================
         WMMA_GEMM_SOFTMAX<Config, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE>(
           sS, sP, sO,
@@ -256,6 +256,9 @@ void launcher_flash_attention_forward(
 ) {
     using Config = KernelConfig<D>;
 
+    const size_t smem = Config::TOTAL_SMEM;
+    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Forward kernel: ", smem, " bytes (", smem / 1024, " KB)");
+
     const int B   = Q.size(0);
     const int H_Q = Q.size(1);
     const int H_K = K.size(1);
@@ -264,38 +267,37 @@ void launcher_flash_attention_forward(
 
     const dim3 grid((M + Config::DO::BLOCK_M - 1) / Config::DO::BLOCK_M, 1, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
-
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Forward kernel: ", smem, " bytes (", smem / 1024, " KB)");
 
     bool is_alibi   = (alibi_slopes != nullptr);
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
 
-    __half* dmask_ptr = dmask.numel() > 0 ? reinterpret_cast<__half*>(dmask.data_ptr()) : nullptr;
+    const __half* q_ptr     = reinterpret_cast<const __half*>(Q.data_ptr());
+    const __half* k_ptr     = reinterpret_cast<const __half*>(K.data_ptr());
+    const __half* v_ptr     = reinterpret_cast<const __half*>(V.data_ptr());
+          __half* out_ptr   = reinterpret_cast<__half*>(Out.data_ptr());
+           float* lse_ptr   = softmax_lse.data_ptr<float>();
+          __half* dmask_ptr = dmask.numel() > 0 ? reinterpret_cast<__half*>(dmask.data_ptr()) : nullptr;
 
     dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-        [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
-            constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
-            constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
-            constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
-            constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
-            constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+        constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
+        constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
+        constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
+        constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
+        constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
 
-            auto kernel = flash_attention_forward_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
-            cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        auto kernel = flash_attention_forward_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
 
-            kernel<<<grid, block, smem, stream>>>(
-                reinterpret_cast<const __half*>(Q.data_ptr()),
-                reinterpret_cast<const __half*>(K.data_ptr()),
-                reinterpret_cast<const __half*>(V.data_ptr()),
-                reinterpret_cast<__half*>(Out.data_ptr()),
-                softmax_lse.data_ptr<float>(), dmask_ptr,
-                B, H_Q, H_K, M, N,
-                softmax_scale, softcap, alibi_slopes, window_left, window_right,
-                p_dropout, dropout_seed, dropout_offset);
-        });
+        kernel<<<grid, block, smem, stream>>>(
+            q_ptr, k_ptr, v_ptr, out_ptr, lse_ptr, dmask_ptr,
+            B, H_Q, H_K, M, N,
+            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            p_dropout, dropout_seed, dropout_offset
+        );
+    });
 }
 
 // ======================================================================================
@@ -324,8 +326,8 @@ std::vector<at::Tensor> flash_attention_forward(
     TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
     TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
     TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
 
     const auto sizes = q.sizes();
     const int B      = sizes[0];
@@ -352,7 +354,9 @@ std::vector<at::Tensor> flash_attention_forward(
         TORCH_CHECK(slopes.dtype() == torch::kFloat32, "alibi_slopes must be fp32");
         TORCH_CHECK(slopes.is_cuda(), "alibi_slopes must be on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        TORCH_CHECK(slopes.sizes() == torch::IntArrayRef({H_Q}) || slopes.sizes() == torch::IntArrayRef({B, H_Q}), "alibi_slopes shape must be [H_Q] or [B, H_Q]");
+        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
         alibi = slopes.data_ptr<float>();
     }
 
@@ -396,7 +400,7 @@ std::vector<at::Tensor> flash_attention_forward(
     // Edge-case return
     if (N == 0) {
         out_fp16.zero_();
-        softmax_lse.fill_(std::numeric_limits<float>::infinity());
+        softmax_lse.fill_(-std::numeric_limits<float>::infinity());
         return {out_fp16, softmax_lse, dmask, rng_state};
     }
 

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -175,7 +175,7 @@ flash_attention_forward_kernel(
         // ==================================================================================
         // Compute:  Online Softmax + O-scaling
         // Layout:   S[BLOCK_M, BLOCK_N] -> P[BLOCK_M, BLOCK_N], O[BLOCK_M, D] scaled
-        // Template: BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE
+        // Template: BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE, TAILS(FALSE)
         // ==================================================================================
         WMMA_GEMM_SOFTMAX<Config, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE>(
           sS, sP, sO,

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -1,0 +1,534 @@
+// ======================================================================================
+// * Copyright (c) 2026, D.Skryabin / tg @ai_bond007 SPDX-License: BSD-3-Clause
+// ======================================================================================
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "debug.h"
+#include "template.h"
+#include "kernel.h"
+#include "forward.h"
+#include "gemm_smem.h"
+#include "mat_mul.h"
+#include "softmax.h"
+#include "dropout.h"
+
+// ======================================================================================
+// FORWARD VARLEN KERNEL
+// ======================================================================================
+template<int D, bool IS_CAUSAL, bool IS_ALIBI, bool IS_SOFTCAP, bool IS_WINDOW, bool IS_DROPOUT>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+flash_attention_forward_varlen_kernel(
+    const __half* __restrict__ Q,
+    const __half* __restrict__ K,
+    const __half* __restrict__ V,
+          __half* __restrict__ Out,
+           float* __restrict__ softmax_lse,
+          __half* __restrict__ dmask,
+    const    int* __restrict__ cu_seqlens_q,
+    const    int* __restrict__ cu_seqlens_k,
+    const    int* __restrict__ seqused_k,
+    const    int* __restrict__ leftpad_k,
+    const    int* __restrict__ block_table,
+    const int      B,
+    const int      H_Q,
+    const int      H_K,
+    const int      T_Q,
+    const int      max_seqlen_k,
+    const int      block_page,
+    const int      block_table_stride,
+    const int      kv_block_stride,
+    const float    softmax_scale,
+    const float    softcap,
+    const float*   alibi_slopes,
+    int            window_left,
+    int            window_right,
+    const float    p_dropout,
+    const uint64_t dropout_seed,
+    const uint64_t dropout_offset
+) {
+    using Config = KernelConfig<D>;
+
+    constexpr int BLOCK_M  = Config::DO::BLOCK_M;
+    constexpr int BLOCK_N  = Config::DO::BLOCK_N;
+    constexpr int D_STRIDE = Config::DO::D_STRIDE;
+    constexpr int N_STRIDE = Config::DO::N_STRIDE;
+
+    // ======================================================================================
+    // Grid Mapping: 1D X for Q-blocks, Z for heads. Batch resolved device-side.
+    // ======================================================================================
+    const int block_idx    = blockIdx.x;
+    const int bthd_idx     = blockIdx.z;
+
+    if (bthd_idx >= H_Q) return;
+
+    // ======================================================================================
+    // BlockInfo: Metadata resolution
+    // ======================================================================================
+    BlockInfo<IS_CAUSAL, IS_WINDOW, true> block;
+    block.init_q(
+        block_idx,       // BLOCK_IDX:      Current Q-block index (grid.x)
+        bthd_idx,        // BATCH_HEAD_ID:  Batch head index
+        H_Q,             // H_Q:            Number of query heads
+        H_K,             // H_K:            Number of KV heads
+        0,               // M:              (unused for varlen)
+        0,               // N:              (unused for varlen)
+        B,               // B:              B (batch size for device-side loop)
+        BLOCK_M,         // BLOCK_M:        Tile size along Q dimension
+        BLOCK_N,         // BLOCK_N:        Tile size along KV dimension
+        window_left,     // WINDOW_LEFT:    Left sliding window bound (-1 if disabled)
+        window_right,    // WINDOW_RIGHT:   Right sliding window bound (-1 if disabled)
+        cu_seqlens_q,    // CU_SEQLENS_Q:   Cumulative Q lengths
+        cu_seqlens_k,    // CU_SEQLENS_K:   Cumulative KV lengths
+        seqused_k        // SEQUSED_K:      Actual KV lengths override
+    );
+
+    if (block.start_q >= block.seqlen_q || block.valid_q_rows <= 0) return;
+
+    // ======================================================================================
+    // EARLY EXIT: No valid KV blocks to attend to (Causal/Window/Empty KV)
+    // Writes deterministic zeros to Out and NEG_INF to LSE for numerical stability.
+    // ======================================================================================
+    if (block.block_min >= block.block_max || block.seqlen_k == 0) {
+        const size_t q_base   = static_cast<size_t>(block.q_base + block.start_q) * H_Q * D + static_cast<size_t>(bthd_idx) * D;
+        const size_t lse_base = static_cast<size_t>(bthd_idx) * T_Q + block.q_base + block.start_q;
+        for (int row = threadIdx.x; row < block.valid_q_rows; row += blockDim.x) {
+            #pragma unroll
+            for (int d = 0; d < D; ++d) {
+                Out[q_base + row * H_Q * D + d] = __float2half(0.0f);
+            }
+            softmax_lse[lse_base + row] = NEG_INF;
+        }
+        return;
+    }
+
+    // ======================================================================================
+    // Init:   thread/warp/lane IDs for WMMA coordination
+    // ======================================================================================
+    const int tid       = threadIdx.x;
+    const int warp_id   = tid >> 5;
+    const int lane_id   = tid & 31;
+    // Alibi slope only for valid block
+    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
+
+    // ======================================================================================
+    // RAGGED POINTERS
+    // Layout:
+    //   Q/Out: [T_Q, H_Q, D]            offset follows q_base + start_q (Q, H_Q, D)
+    //   LSE:   [H_Q, T_Q]               offset follows bthd_idx * T_Q (H_Q, T_Q)
+    //   dmask: [T_Q, H_Q, max_seqlen_k] offset follows q_base + start_q (max_seqlen_k, H_Q, T_Q)
+    // ======================================================================================
+    const __half* __restrict__ q_ptr           = Q           + block.q_offset  (D, H_Q, T_Q);
+          __half* __restrict__ out_ptr         = Out         + block.q_offset  (D, H_Q, T_Q);
+           float* __restrict__ softmax_lse_ptr = softmax_lse + block.lse_offset(H_Q, T_Q);
+          __half* __restrict__ dmask_ptr       = (dmask != nullptr) ? dmask + block.dmask_offset(H_Q, T_Q, max_seqlen_k) : nullptr;
+
+    // ======================================================================================
+    // INIT SHARED MEMORY
+    // ======================================================================================
+    extern __shared__ char smem_raw[];
+
+    WMMA_GEMM_INIT_SMEM<Config>(smem_raw);
+
+    __syncthreads();
+
+    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+    __half* __restrict__ sQ      = smem.phase.fdo.q;
+    __half* __restrict__ sK      = smem.phase.fdo.reuse_kv.k;
+    __half* __restrict__ sV      = smem.phase.fdo.reuse_kv.v;
+    float*  __restrict__ sS      = smem.phase.fdo.reuse_sp.s;
+    __half* __restrict__ sP      = smem.phase.fdo.reuse_sp.p;
+    float*  __restrict__ sRowMax = smem.row_max;
+    float*  __restrict__ sRowSum = smem.row_sum;
+    float*  __restrict__ sO      = smem.phase.fdo.o;
+
+    if (tid < BLOCK_M) {
+        sRowMax[tid] = NEG_INF;
+    }
+
+    // ======================================================================================
+    // Load:     Q tile from global to sQ shared memory
+    // Layout:   Q: global[row: BLOCK_M, H_Q * D] -> shared[row: BLOCK_M, D_STRIDE]
+    // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D
+    // ======================================================================================
+    WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+      q_ptr,   sQ,
+      nullptr, nullptr,
+      H_Q * D, block.valid_q_rows, tid);
+    __syncthreads();
+
+    // ======================================================================================
+    // MAIN LOOP (Iterates over logical KV blocks)
+    // ======================================================================================
+    for (int block_q = block.block_min; block_q < block.block_max; ++block_q) {
+        const int start_kv      = block_q * BLOCK_N;
+        const int valid_kv_rows = min(BLOCK_N, block.seqlen_k - start_kv);
+        if (valid_kv_rows <= 0) break;
+
+        // ======================================================================================
+        // KV-CACHE (Paged vs Contiguous)
+        // ======================================================================================
+        const __half* __restrict__ k_ptr_page;
+        const __half* __restrict__ v_ptr_page;
+
+        if (block_table != nullptr) {
+            const int page_idx    = start_kv / block_page;
+            const int page_offset = start_kv % block_page;
+            const int bt_idx      = block.batch_idx * block_table_stride + page_idx;
+            const int phys_page   = block_table[bt_idx];
+            const size_t kv_load  = static_cast<size_t>(phys_page) * kv_block_stride +
+                                    static_cast<size_t>(page_offset) * H_K * D +
+                                    static_cast<size_t>(block.kv_head_idx) * D;
+            k_ptr_page = K + kv_load;
+            v_ptr_page = V + kv_load;
+        } else {
+            const size_t kv_load  = static_cast<size_t>(block.k_base + start_kv) * H_K * D +
+                                    static_cast<size_t>(block.kv_head_idx) * D;
+            k_ptr_page = K + kv_load;
+            v_ptr_page = V + kv_load;
+        }
+
+        // ======================================================================================
+        // Load:     K tile from global to sK shared memory
+        // Layout:   K: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+        // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+          k_ptr_page, sK,
+          nullptr,    nullptr,
+          H_K * D, valid_kv_rows, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  S = Q @ K^T
+        // Layout:   sQ[valid_q_rows, D_STRIDE] @ sK^T -> sS[valid_q_rows, N_STRIDE]
+        // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+        // ======================================================================================
+        WMMA_GEMM_SCORES<Config, GemmType::sQ_KT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_M, BLOCK_N, D_STRIDE, N_STRIDE>(
+          sQ, sK, sS,
+          block.valid_q_rows,  valid_kv_rows,
+          block.start_q,       start_kv,
+          block.seqlen_offset,
+          softmax_scale, softcap, alibi_slope, window_left, window_right, warp_id, lane_id);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  Online softmax + O rescaling (block_q > 0)
+        // Layout:   sS[valid_q_rows, N_STRIDE] -> sP[valid_q_rows, N_STRIDE]
+        //           sO[valid_q_rows, D_STRIDE] *= exp(old_max - new_max)
+        // Template: SCORE_STRIDE=N_STRIDE, HEAD_STRIDE=D_STRIDE, TILES=true (varlen tail handling)
+        // ======================================================================================
+        WMMA_GEMM_SOFTMAX<Config, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE, true>(
+          sS, sP, sO,
+          sRowMax, sRowSum,
+          block.valid_q_rows, valid_kv_rows, tid, block_q);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  Dropout mask application
+        // Layout:   sP[row: valid_q_rows, N_STRIDE] masked, dmask stored if requested
+        // Varlen:   GLOBAL_N=block.seqlen_k (actual KV length) for correct RNG stride
+        // Template: IS_DROPOUT guards compile-time; runtime p_dropout > 0 enables execution
+        // ======================================================================================
+        WMMA_GEMM_DROPOUT<Config, BLOCK_M, BLOCK_N, N_STRIDE, IS_DROPOUT>(
+          sP, dmask_ptr ? dmask_ptr + start_kv : nullptr,
+          block.valid_q_rows, valid_kv_rows,
+          block.q_base + block.start_q, start_kv, block.seqlen_k,
+          p_dropout, dropout_seed, dropout_offset, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // Load:     V tile from global to sV shared memory
+        // Layout:   V: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+        // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+          v_ptr_page, sV,
+          nullptr,    nullptr,
+          H_K * D, valid_kv_rows, tid);
+        __syncthreads();
+
+        // ==============================================================================
+        // Compute:  dO += P @ V
+        // Layout:   sP[valid_q_rows, N_STRIDE] @ sV[valid_kv_rows, D_STRIDE] += sO
+        // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+        // ==============================================================================
+        WMMA_GEMM_GRADIENTS<Config, GemmType::dO_PV, D, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE>(
+          sP, sV, sO,
+          block.valid_q_rows, valid_kv_rows,
+          warp_id, lane_id);
+        __syncthreads();
+    }   // END MAIN LOOP
+    // ======================================================================================
+    // Compute:  Store normalized attention output O = softmax(S) @ V
+    // Layout:   sO[row: valid_q_rows, D_STRIDE] -> out_ptr[row: valid_q_rows, H_Q * D]
+    // Template: SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile store)
+    // ======================================================================================
+    WMMA_GEMM_EPILOGUE<Config, GemmType::write_dO, D_STRIDE, D>(
+      sO,      out_ptr,
+      nullptr, nullptr,
+      sRowSum, H_Q * D, block.valid_q_rows, tid);
+
+    if (tid < block.valid_q_rows) {
+        const float sum = fmaxf(sRowSum[tid], 1e-24f);
+        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+    }
+}
+
+// ======================================================================================
+// LAUNCHER
+// ======================================================================================
+template<int D>
+void launcher_flash_attention_forward_varlen(
+    const torch::Tensor& Q,
+    const torch::Tensor& K,
+    const torch::Tensor& V,
+          torch::Tensor& Out,
+          torch::Tensor& softmax_lse,
+    const torch::Tensor& dmask,
+    const torch::Tensor& cu_seqlens_q,
+    const torch::Tensor& cu_seqlens_k,
+    const torch::Tensor& seqused_k,
+    const torch::Tensor& leftpad_k,
+    const torch::Tensor& block_table,
+    const bool   paged_KV,
+    const int    T_Q,
+    const int    max_seqlen_q,
+    const int    max_seqlen_k,
+    float        softmax_scale,
+    bool         is_causal,
+    float        softcap,
+    float        p_dropout,
+    const float* alibi_slopes,
+    int          window_left,
+    int          window_right,
+    uint64_t     dropout_seed,
+    uint64_t     dropout_offset,
+    cudaStream_t stream
+) {
+    using Config = KernelConfig<D>;
+
+    const size_t smem = Config::TOTAL_SMEM;
+    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Forward varlen kernel: ", smem, " bytes (", smem / 1024, " KB)");
+
+    const int B                  = cu_seqlens_q.size(0) - 1;
+    const int H_Q                = Q.size(1);
+    const int H_K                = paged_KV ? K.size(2) : K.size(1);
+    const int block_page         = paged_KV ? K.size(1) : 1;
+    const int block_table_stride = (paged_KV && block_table.defined()) ? block_table.stride(0) : 0;
+    const int kv_block_stride    = paged_KV ? K.stride(0) : 0;
+
+    const dim3 grid((max_seqlen_q + Config::DO::BLOCK_M - 1) / Config::DO::BLOCK_M, 1, B * H_Q);
+    const dim3 block(Config::THREADS_PER_BLOCK);
+
+    bool is_alibi   = (alibi_slopes != nullptr);
+    bool is_softcap = (softcap > 0.0f);
+    bool is_window  = (window_left >= 0 || window_right >= 0);
+    bool is_dropout = (p_dropout > 0.0f);
+
+    const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
+    const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
+    const __half* v_ptr            = reinterpret_cast<const __half*>(V.data_ptr());
+          __half* out_ptr          = reinterpret_cast<__half*>(Out.data_ptr());
+           float* lse_ptr          = softmax_lse.data_ptr<float>();
+          __half* dmask_ptr        = dmask.numel() > 0 ? reinterpret_cast<__half*>(dmask.data_ptr()) : nullptr;
+    const int*    cu_seqlens_q_ptr = cu_seqlens_q.data_ptr<int>();
+    const int*    cu_seqlens_k_ptr = cu_seqlens_k.data_ptr<int>();
+    const int*    seqused_k_ptr    = seqused_k.defined() ? seqused_k.data_ptr<int>() : nullptr;
+    const int*    leftpad_k_ptr    = leftpad_k.defined() ? leftpad_k.data_ptr<int>() : nullptr;
+    const int*    block_table_ptr  = paged_KV ? block_table.data_ptr<int>() : nullptr;
+
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+        constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
+        constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
+        constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
+        constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
+        constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
+
+        auto kernel = flash_attention_forward_varlen_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+
+        kernel<<<grid, block, smem, stream>>>(
+            q_ptr, k_ptr, v_ptr, out_ptr, lse_ptr, dmask_ptr,
+            cu_seqlens_q_ptr, cu_seqlens_k_ptr,
+            seqused_k_ptr, leftpad_k_ptr, block_table_ptr,
+            B, H_Q, H_K, T_Q, max_seqlen_k,
+            block_page, block_table_stride, kv_block_stride,
+            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            p_dropout, dropout_seed, dropout_offset
+        );
+    });
+}
+
+// ======================================================================================
+// WRAPPER
+// ======================================================================================
+std::vector<at::Tensor> flash_attention_varlen_forward(
+          at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    std::optional<at::Tensor> &out,
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    std::optional<at::Tensor> &seqused_k,
+    std::optional<const at::Tensor> &leftpad_k,
+    std::optional<at::Tensor> &block_table,
+    std::optional<at::Tensor> alibi_slopes,
+    int          max_seqlen_q,
+    const int    max_seqlen_k,
+    const float  p_dropout,
+    const float  softmax_scale,
+    const bool   zero_tensors,
+    bool         is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool   return_softmax,
+    std::optional<at::Generator> gen,
+    int          num_splits
+) {
+    // Device guard for multi-GPU / pipeline-parallelism
+    at::cuda::CUDAGuard device_guard{q.device()};
+
+    auto props = at::cuda::getCurrentDeviceProperties();
+    TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
+
+    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
+
+    const int T_Q = q.size(0);
+    const int H_Q = q.size(1);
+    const int D   = q.size(2);
+    const int B   = cu_seqlens_q.size(0) - 1;
+    const bool paged_KV = block_table.has_value();
+
+    at::Tensor block_table_t;
+    int H_K = paged_KV ? k.size(2) : k.size(1);
+    int page_block_size = paged_KV ? k.size(1) : 1;
+
+    if (paged_KV) {
+        block_table_t = block_table.value();
+        TORCH_CHECK(block_table_t.is_cuda(), "block_table must be on CUDA");
+        TORCH_CHECK(block_table_t.dtype() == torch::kInt32, "block_table must have dtype torch.int32");
+        TORCH_CHECK(block_table_t.stride(-1) == 1, "block_table must have contiguous last dimension");
+        TORCH_CHECK(page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
+        TORCH_CHECK(k.sizes() == v.sizes(), "K and V paged shapes must match");
+    }
+
+    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32 && cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens must be int32");
+    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA device");
+    TORCH_CHECK(cu_seqlens_q.is_contiguous() && cu_seqlens_k.is_contiguous(), "cu_seqlens must be contiguous");
+    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D tensors");
+
+    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
+    TORCH_CHECK(B > 0, "batch_size must be positive");
+
+    if (seqused_k.has_value()) {
+        auto seqused = seqused_k.value();
+        TORCH_CHECK(seqused.dtype() == torch::kInt32 && seqused.is_cuda() && seqused.is_contiguous(), "seqused_k must be int32, contiguous, on CUDA");
+        TORCH_CHECK(seqused.dim() == 1 && seqused.size(0) == B, "seqused_k must be 1D with size == batch_size");
+    }
+
+    if (leftpad_k.has_value()) {
+        TORCH_CHECK(!paged_KV, "Paged KV and leftpad_k are not supported simultaneously");
+        auto leftpad = leftpad_k.value();
+        TORCH_CHECK(leftpad.dtype() == torch::kInt32 && leftpad.is_cuda() && leftpad.is_contiguous(), "leftpad_k must be int32, contiguous, on CUDA");
+        TORCH_CHECK(leftpad.dim() == 1 && leftpad.size(0) == B, "leftpad_k must be 1D with size == batch_size");
+    }
+
+    // Window edge cases
+    if (window_left  >= max_seqlen_k) window_left  = -1;
+    if (window_right >= max_seqlen_k) window_right = -1;
+
+    // Alibi
+    const float* alibi = nullptr;
+    if (alibi_slopes.has_value()) {
+        const auto& slopes = alibi_slopes.value();
+        auto sizes = slopes.sizes();
+        TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
+        TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
+        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi = slopes.data_ptr<float>();
+    }
+
+    // Dropout
+    TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
+    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
+
+    uint64_t dropout_seed   = 0;
+    uint64_t dropout_offset = 0;
+    at::Tensor rng_state = torch::empty({2}, torch::dtype(torch::kInt64).device(q.device()));
+
+    if (p_dropout > 0.0f) {
+        auto gen_cuda = at::get_generator_or_default<at::CUDAGeneratorImpl>(gen, at::cuda::detail::getDefaultCUDAGenerator());
+        std::lock_guard<std::mutex> lock(gen_cuda->mutex_);
+        dropout_seed   = gen_cuda->current_seed();
+        dropout_offset = gen_cuda->get_offset();
+        uint64_t counter_offset = static_cast<uint64_t>(T_Q) * static_cast<uint64_t>(H_Q) * 32ULL;
+        gen_cuda->set_offset(dropout_offset + counter_offset);
+        rng_state[0] = static_cast<int64_t>(dropout_seed);
+        rng_state[1] = static_cast<int64_t>(dropout_offset);
+    }
+
+    // Output tensors
+    at::Tensor out_fp16 = out.has_value() ? out.value() : torch::empty_like(q);
+    auto softmax_lse = torch::empty({H_Q, T_Q}, torch::dtype(torch::kFloat32).device(q.device()));
+    TORCH_CHECK(out_fp16.dtype()    == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+
+    at::Tensor dmask;
+    if (return_softmax && p_dropout > 0.0f) {
+        dmask = torch::empty({T_Q, H_Q, max_seqlen_k}, q.options());
+    } else {
+        dmask = torch::empty({0}, q.options());
+    }
+
+    // Edge-case return
+    if (zero_tensors) {
+        out_fp16.zero_();
+        softmax_lse.fill_(-std::numeric_limits<float>::infinity());
+        if (dmask.numel() > 0) dmask.zero_();
+    }
+
+    if (T_Q == 0 || max_seqlen_k == 0) {
+        return {out_fp16, softmax_lse, dmask, rng_state};
+    }
+
+    // Run kernel
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    #define LAUNCH_KERNEL(DIM) \
+        launcher_flash_attention_forward_varlen<DIM>(q, k, v, out_fp16, softmax_lse, dmask, \
+            cu_seqlens_q, cu_seqlens_k, seqused_k.value_or(torch::Tensor()), \
+            leftpad_k.has_value() ? leftpad_k.value() : torch::Tensor(), \
+            block_table_t, paged_KV, T_Q, max_seqlen_q, max_seqlen_k, \
+            softmax_scale, is_causal, softcap, p_dropout, alibi, \
+            window_left, window_right, dropout_seed, dropout_offset, stream);
+
+    switch (D) {
+        case 16:  LAUNCH_KERNEL(16);  break;
+        case 32:  LAUNCH_KERNEL(32);  break;
+        case 64:  LAUNCH_KERNEL(64);  break;
+        case 128: LAUNCH_KERNEL(128); break;
+        case 256: LAUNCH_KERNEL(256); break;
+        default: TORCH_CHECK(false, "Unsupported D: ", D);
+    }
+    #undef LAUNCH_KERNEL
+
+    return {out_fp16, softmax_lse, dmask, rng_state};
+}

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ def get_ext_modules():
             sources=[
                 "kernel/fused_mha_api.cpp",
                 "kernel/fused_mha_forward.cu",
+                "kernel/fused_mha_forward_varlen.cu",
                 "kernel/fused_mha_backward.cu",
             ],
             include_dirs=[this_dir / "include"],

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ def get_ext_modules():
                 "kernel/fused_mha_forward.cu",
                 "kernel/fused_mha_forward_varlen.cu",
                 "kernel/fused_mha_backward.cu",
+                "kernel/fused_mha_backward_varlen.cu",
             ],
             include_dirs=[this_dir / "include"],
             extra_compile_args={


### PR DESCRIPTION
* `0e33d7e` **Template: Move to 2D grid mapping (Y = batch_head_id):** Refactors CUDA grid layout to use a 2D configuration where `blockIdx.y` directly resolves batch/head composites. Removes expensive device-side division/modulo for coordinate calculation, simplifies block scheduling, and improves SM occupancy.

* `6408aab` **Softmax: Updated tiling strategy for dense/varlen kernels:** Adjusts online softmax accumulation tiles to match the new load/store pipeline. Enhances numerical stability during max/sum rescaling and reduces register pressure in the normalization phase.

* `302f80d` **Tile Load: Revised tile loading strategy for dense/varlen kernels:** Overhauls global→shared memory tile loading to strictly align with Volta WMMA fragment layouts. Improves memory coalescing, reduces shared memory bank conflicts, and unifies load patterns across both dense and varlen passes.

* `f5490b7` **Epilogue: Optimized result write-back strategy for dense/varlen kernels:** Restructures the final shared→global store phase. Consolidates output/gradient writes, guarantees fully coalesced tail-block stores, and minimizes epilogue synchronization overhead.

* `8ee7276` **Forward/Varlen: Add new forward variable-length kernel:** Introduces a native varlen forward kernel to process ragged sequences without padding. Eliminates wasted compute on masked tokens, routes `cu_seqlens` device-side, and improves memory efficiency for dynamic sequence lengths.

* `ec725b8` **Forward/Backward: Reviewed and fixed launchers and wrappers:** Audits and corrects C++ launcher signatures, tensor stride validations, and optional argument routing. Ensures strict ABI compatibility, eliminates edge-case launch failures, and synchronizes dense/varlen wrapper logic.

* `b056e2d` **Backward/Varlen: Add new backward variable-length kernel:** Implements the corresponding backward pass for ragged layouts. Supports efficient gradient computation across variable sequences with proper `cu_seqlens` indexing, online softmax rescaling, and GQA/MQA head expansion.

* `de68df3` **Interface: Updated autograd & flash_attn Python interface:** Aligns the Python API with the refactored C++ backend. Adds explicit `varlen_fwd`/`varlen_bwd` routing, enforces `cu_seqlens` dtype safety (`int32`), and stabilizes `torch.autograd.Function` contexts for seamless dense ↔ varlen training.