### PR TITLE
Forward: Add full features support for flash_attn_with_kvcache() API

### DIFF
--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -7,6 +7,8 @@ from flash_attn_v100 import (
     flash_attn_gpu,
     flash_attn_varlen_func,
     flash_attn_varlen_gpu,
+    flash_attn_with_kvcache,
+    flash_attn_with_kvcache_gpu,
     __version__ as _v100_version
 )
 
@@ -17,6 +19,8 @@ __all__ = [
     "flash_attn_gpu",
     "flash_attn_varlen_func",
     "flash_attn_varlen_gpu",
+    "flash_attn_with_kvcache",
+    "flash_attn_with_kvcache_gpu",
     "__version__"
 ]
 

--- a/flash_attn_v100/__init__.py
+++ b/flash_attn_v100/__init__.py
@@ -4,12 +4,16 @@ from .flash_attn_interface import (
     flash_attn_func,
     flash_attn_gpu,
     flash_attn_varlen_func,
-    flash_attn_varlen_gpu
+    flash_attn_varlen_gpu,
+    flash_attn_with_kvcache,
+    flash_attn_with_kvcache_gpu
 )
 
 __all__ = [
     "flash_attn_func",
     "flash_attn_gpu",
     "flash_attn_varlen_func",
-    "flash_attn_varlen_gpu"
+    "flash_attn_varlen_gpu",
+    "flash_attn_with_kvcache",
+    "flash_attn_with_kvcache_gpu"
 ]

--- a/flash_attn_v100/flash_attn_interface.py
+++ b/flash_attn_v100/flash_attn_interface.py
@@ -6,7 +6,7 @@ import torch
 import warnings
 import traceback
 import flash_attn_v100_cuda
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 def maybe_contiguous(x: torch.Tensor) -> torch.Tensor:
     return x.contiguous() if x is not None and not x.is_contiguous() else x
@@ -28,7 +28,8 @@ class FlashAttnFunc(torch.autograd.Function):
         softcap: float,
         alibi_slopes: Optional[torch.Tensor],
         deterministic: bool,
-        return_attn_probs: bool = False
+        return_softmax: bool,
+        is_grad_enabled: bool
     ) -> torch.Tensor:
         q_ = q.permute(0, 2, 1, 3)
         k_ = k.permute(0, 2, 1, 3)
@@ -58,12 +59,12 @@ class FlashAttnFunc(torch.autograd.Function):
             q_, k_, v_, None, alibi_slopes,
             dropout_p, softmax_scale, causal,
             window_left, window_right, softcap,
-            return_attn_probs, None
+            return_softmax, None
         )
 
         out = out_[..., :head_size_og].permute(0, 2, 1, 3).contiguous()
 
-        if q.requires_grad or k.requires_grad or v.requires_grad:
+        if is_grad_enabled and (q.requires_grad or k.requires_grad or v.requires_grad):
             ctx.save_for_backward(q_, k_, v_, out_, lse_, rng_state)
             ctx.dropout_p = dropout_p
             ctx.softmax_scale = softmax_scale
@@ -75,7 +76,7 @@ class FlashAttnFunc(torch.autograd.Function):
             ctx.head_size_og = head_size_og
             ctx.pad_size = pad_size
 
-        return (out, lse_, dmask_) if return_attn_probs else out
+        return (out, lse_, dmask_) if return_softmax else out
 
     @staticmethod
     def backward(ctx, dout, *args):
@@ -106,7 +107,7 @@ class FlashAttnFunc(torch.autograd.Function):
         dk = grads[1][..., :head_size_og].permute(0, 2, 1, 3).contiguous()
         dv = grads[2][..., :head_size_og].permute(0, 2, 1, 3).contiguous()
 
-        return dq, dk, dv, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None
 
 
 def flash_attn_func(
@@ -129,8 +130,18 @@ def flash_attn_func(
 
     try:
         return FlashAttnFunc.apply(
-            q, k, v, dropout_p, softmax_scale, causal,
-            window_size, softcap, alibi_slopes, deterministic, return_attn_probs
+            q,
+            k,
+            v,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            softcap,
+            alibi_slopes,
+            deterministic,
+            return_attn_probs,
+            torch.is_grad_enabled()
         )
     except Exception as e:
         print(f"[VOLTA FA2 DENSE FAILED] {type(e).__name__}: {e}")
@@ -161,8 +172,6 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         deterministic: bool,
         return_attn_probs: bool,
         block_table: Optional[torch.Tensor],
-        seqused_k: Optional[torch.Tensor],
-        leftpad_k: Optional[torch.Tensor],
         is_grad_enabled: bool
     ) -> torch.Tensor:
         cu_seqlens_q = cu_seqlens_q.to(torch.int32)
@@ -189,12 +198,16 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
 
         window_left, window_right = window_size
 
+        seqused_k = None
+        leftpad_k = None
+        num_splits = 0
+
         out, lse, dmask, rng_state = flash_attn_v100_cuda.varlen_fwd(
             q, k, v, None, cu_seqlens_q, cu_seqlens_k,
             seqused_k, leftpad_k, block_table, alibi_slopes,
             max_seqlen_q, max_seqlen_k, dropout_p, softmax_scale,
             False, causal, window_left, window_right, softcap,
-            return_attn_probs and dropout_p > 0.0, None, 0
+            return_attn_probs and dropout_p > 0.0, None, num_splits
         )
 
         out = out[..., :head_size_og].contiguous()
@@ -248,7 +261,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         dk = grads[1][..., :head_size_og].contiguous()
         dv = grads[2][..., :head_size_og].contiguous()
 
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def flash_attn_varlen_func(
@@ -268,8 +281,6 @@ def flash_attn_varlen_func(
     deterministic: bool = False,
     return_attn_probs: bool = False,
     block_table: Optional[torch.Tensor] = None,
-    seqused_k: Optional[torch.Tensor] = None,
-    leftpad_k: Optional[torch.Tensor] = None
 ):
     """Varlen Flash Attention (T, H, D)"""
     if deterministic:
@@ -278,10 +289,22 @@ def flash_attn_varlen_func(
 
     try:
         return FlashAttnVarlenFunc.apply(
-            q, k, v, cu_seqlens_q, cu_seqlens_k,
-            max_seqlen_q, max_seqlen_k, dropout_p, softmax_scale, causal,
-            window_size, softcap, alibi_slopes, deterministic,
-            return_attn_probs, block_table, seqused_k, leftpad_k,
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            softcap,
+            alibi_slopes,
+            deterministic,
+            return_attn_probs,
+            block_table,
             torch.is_grad_enabled()
         )
     except Exception as e:
@@ -290,10 +313,103 @@ def flash_attn_varlen_func(
         raise
 
 
+# ======================================================================================
+# KV ATTENTION (B, M, H, D) -> (B, H, M, D)
+# ======================================================================================
+def flash_attn_with_kvcache(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    k: Optional[torch.Tensor] = None,
+    v: Optional[torch.Tensor] = None,
+    rotary_cos: Optional[torch.Tensor] = None,
+    rotary_sin: Optional[torch.Tensor] = None,
+    cache_seqlens: Optional[Union[int, torch.Tensor]] = None,
+    cache_batch_idx: Optional[torch.Tensor] = None,
+    cache_leftpad: Optional[torch.Tensor] = None,
+    block_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[int, int] = (-1, -1),
+    softcap: float = 0.0,
+    rotary_interleaved: bool = True,
+    alibi_slopes: Optional[torch.Tensor] = None,
+    num_splits: int = 0,
+    return_softmax_lse: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """
+    FlashAttention with KV cache (B, M, H, D) for incremental decoding.
+    If k and v are not None, k_cache and v_cache will be updated *inplace* with the new values.
+    Note: Does not support backward pass.
+    """
+    assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
+    assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
+
+    q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
+
+    q_ = q.permute(0, 2, 1, 3).contiguous()
+    k_cache_ = k_cache
+    v_cache_ = v_cache
+
+    if k is not None:
+        k_ = k.permute(0, 2, 1, 3).contiguous()
+    else:
+        k_ = None
+
+    if v is not None:
+        v_ = v.permute(0, 2, 1, 3).contiguous()
+    else:
+        v_ = None
+
+    if softmax_scale is None:
+        softmax_scale = q_.shape[-1] ** (-0.5)
+
+    if cache_seqlens is not None and isinstance(cache_seqlens, int):
+        cache_seqlens = torch.full(
+            (q_.shape[0],), cache_seqlens, dtype=torch.int32, device=k_cache_.device
+        )
+        cache_seqlens = maybe_contiguous(cache_seqlens)
+
+    cache_batch_idx = maybe_contiguous(cache_batch_idx)
+    block_table = maybe_contiguous(block_table)
+    out_ = torch.empty_like(q_)
+
+    out_, softmax_lse = flash_attn_v100_cuda.fwd_kvcache(
+        q_,
+        k_cache_,
+        v_cache_,
+        k_,
+        v_,
+        cache_seqlens,
+        rotary_cos,
+        rotary_sin,
+        cache_batch_idx,
+        cache_leftpad,
+        block_table,
+        alibi_slopes,
+        out_,
+        softmax_scale,
+        causal,
+        window_size[0],
+        window_size[1],
+        softcap,
+        rotary_interleaved,
+        num_splits,
+    )
+
+    out = out_.permute(0, 2, 1, 3).contiguous()
+
+    if return_softmax_lse:
+        return out, softmax_lse
+    return out
+
+
 flash_attn_gpu = flash_attn_func
 flash_attn_varlen_gpu = flash_attn_varlen_func
+flash_attn_with_kvcache_gpu = flash_attn_with_kvcache
 
 __all__ = [
     "flash_attn_func", "flash_attn_gpu",
-    "flash_attn_varlen_func", "flash_attn_varlen_gpu"
+    "flash_attn_varlen_func", "flash_attn_varlen_gpu",
+    "flash_attn_with_kvcache", "flash_attn_with_kvcache_gpu"
 ]

--- a/include/mha.h
+++ b/include/mha.h
@@ -193,3 +193,53 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     std::optional<at::Generator> gen,
     std::optional<at::Tensor>& rng_state
 );
+
+/**
+ * FlashAttention Forward Pass with KV-Cache (Paged / Variable-Length)
+ *
+ * @param q                   Query tensor                           [B, M, H, D]         (fp16, input)
+ * @param kcache              Key cache tensor                       [B_c, N, H_k, D]     (fp16, input)
+ *                            or [num_blocks, page_block_size, H_k, D] if block_table is set
+ * @param vcache              Value cache tensor                     [B_c, N, H_k, D]     (fp16, input)
+ *                            or [num_blocks, page_block_size, H_k, D] if block_table is set
+ * @param k                   Optional new key tensor                [B, M_new, H_k, D]   (fp16, input)
+ * @param v                   Optional new value tensor              [B, M_new, H_k, D]   (fp16, input)
+ * @param seqlens_k           Optional actual sequence lengths for K [B]                  (int32, input)
+ * @param rotary_cos          Cosine frequencies for RoPE            [seqlen_ro, D_ro/2]  (fp16, input)
+ * @param rotary_sin          Sine frequencies for RoPE              [seqlen_ro, D_ro/2]  (fp16, input)
+ * @param cache_batch_idx     Indices to index into the KV cache     [B]                  (int32, input)
+ * @param leftpad_k           Optional left padding offsets for K    [B]                  (int32, input)
+ * @param block_table         Optional block table for paged attn    [B, max_blocks]      (int32, input)
+ * @param alibi_slopes        Optional ALiBi slopes tensor           [H] or [B, H]        (fp32, input)
+ * @param out                 Optional output tensor                 [B, M, H, D]         (fp16, output)
+ * @param softmax_scale       Softmax scale factor                   (float, input)
+ * @param is_causal           Enable causal masking                  (bool, input)
+ * @param window_left         Left window size for sliding attn      (int, input)
+ * @param window_right        Right window size for sliding attn     (int, input)
+ * @param softcap             Soft capping value for logits          (float, input)
+ * @param is_rotary_interleaved  If true, RoPE interleaves dims 0,1; else 0, D_ro/2 (bool, input)
+ * @param num_splits          KV-cache split heuristic               (int, input)
+ * @return                    Vector of output tensors {out, softmax_lse}
+ */
+std::vector<at::Tensor> flash_attention_kvcache(
+    at::Tensor &q,
+    const at::Tensor &kcache,
+    const at::Tensor &vcache,
+    std::optional<const at::Tensor> &k,
+    std::optional<const at::Tensor> &v,
+    std::optional<const at::Tensor> &seqlens_k,
+    std::optional<const at::Tensor> &rotary_cos,
+    std::optional<const at::Tensor> &rotary_sin,
+    std::optional<const at::Tensor> &cache_batch_idx,
+    std::optional<const at::Tensor> &leftpad_k,
+    std::optional<at::Tensor> &block_table,
+    std::optional<at::Tensor> alibi_slopes,
+    std::optional<at::Tensor> &out,
+    const float  softmax_scale,
+    bool         is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    bool         is_rotary_interleaved,
+    int          num_splits = 0
+);

--- a/include/rotary.h
+++ b/include/rotary.h
@@ -1,0 +1,247 @@
+// ======================================================================================
+// * Copyright (c) 2025, D.Skryabin / tg @ai_bond007 SPDX-License: BSD-3-Clause
+// ======================================================================================
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+// ======================================================================================
+// KV-CACHE UPDATER: Global(K_NEW/V_NEW) -> Registers -> (RoPE on K) -> Global(K_CACHE/V_CACHE)
+// ======================================================================================
+template<typename Config, int GLOBAL_STRIDE, bool IS_ROPE, bool IS_INTERLEAVED>
+__device__ __forceinline__ void WMMA_GEMM_UPDATE_KVCACHE(
+    const __half* __restrict__ K_NEW,
+    const __half* __restrict__ V_NEW,
+          __half* __restrict__ K_CACHE,
+          __half* __restrict__ V_CACHE,
+    const __half* __restrict__ ROTARY_COS,
+    const __half* __restrict__ ROTARY_SIN,
+    int T_NEW,
+    int H_K,
+    int STRIDE_NEW_B,   int STRIDE_NEW_S,   int STRIDE_NEW_H,
+    int STRIDE_CACHE_B, int STRIDE_CACHE_S, int STRIDE_CACHE_H,
+    int BATCH_IDX,
+    int KV_HEAD_IDX,
+    int CACHE_BIDX,
+    int CACHE_SEQLEN,
+    int ROTARY_DIM,
+    int LEFTPAD,
+    int THREAD_ID
+) {
+    if (K_NEW == nullptr || V_NEW == nullptr || T_NEW <= 0 || KV_HEAD_IDX >= H_K) return;
+
+    constexpr int THREADS      = Config::THREADS_PER_BLOCK;
+    constexpr int CHUNKS       = GLOBAL_STRIDE / 8;
+    const     int total_iters  = T_NEW * CHUNKS;
+
+    if (total_iters == 0) return;
+
+    const int half_rot      = IS_ROPE ? (ROTARY_DIM / 2) : 0;
+
+    uint64_t base_k_new   = reinterpret_cast<uint64_t>(K_NEW);
+    uint64_t base_v_new   = reinterpret_cast<uint64_t>(V_NEW);
+    uint64_t base_k_cache = reinterpret_cast<uint64_t>(K_CACHE);
+    uint64_t base_v_cache = reinterpret_cast<uint64_t>(V_CACHE);
+
+    #pragma unroll 2
+    for (int idx = THREAD_ID; idx < total_iters; idx += THREADS) {
+        const int row    = idx / CHUNKS;
+        const int chunk  = idx % CHUNKS;
+        const int d_base = chunk * 8;
+
+        const size_t off_new   = static_cast<size_t>(BATCH_IDX)    * STRIDE_NEW_B +
+                                 static_cast<size_t>(KV_HEAD_IDX)  * STRIDE_NEW_H +
+                                 static_cast<size_t>(row)          * STRIDE_NEW_S + d_base;
+        const size_t off_cache = static_cast<size_t>(CACHE_BIDX)   * STRIDE_CACHE_B +
+                                 static_cast<size_t>(KV_HEAD_IDX)  * STRIDE_CACHE_H +
+                                 static_cast<size_t>(CACHE_SEQLEN  + LEFTPAD + row) * STRIDE_CACHE_S + d_base;
+
+        uint64_t src_k = base_k_new   + off_new * 2;
+        uint64_t src_v = base_v_new   + off_new * 2;
+        uint64_t dst_k = base_k_cache + off_cache * 2;
+        uint64_t dst_v = base_v_cache + off_cache * 2;
+
+        uint32_t k[4], v[4];
+
+        asm volatile("ld.global.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(k[0]), "=r"(k[1]), "=r"(k[2]), "=r"(k[3]) : "l"(src_k));
+        asm volatile("ld.global.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(v[0]), "=r"(v[1]), "=r"(v[2]), "=r"(v[3]) : "l"(src_v));
+
+        if constexpr(IS_ROPE) {
+            const int pos = CACHE_SEQLEN + LEFTPAD + row;
+            if (IS_INTERLEAVED) {
+                #pragma unroll
+                for (int i = 0; i < 4; ++i) {
+                    int d = d_base + i * 2;
+
+                    if (d >= ROTARY_DIM) break;
+
+                    half2 x   = *reinterpret_cast<half2*>(&k[i]);
+                    float2 xf = __half22float2(x);
+                    float c   = __half2float(ROTARY_COS[pos * half_rot + d / 2]);
+                    float s   = __half2float(ROTARY_SIN[pos * half_rot + d / 2]);
+                    float y0  = __fmaf_rn(xf.x, c, -xf.y * s);
+                    float y1  = __fmaf_rn(xf.x, s,  xf.y * c);
+                    half2 y   = __float22half2_rn(make_float2(y0, y1));
+                    k[i]      = *reinterpret_cast<uint32_t*>(&y);
+                }
+                asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_k), "r"(k[0]), "r"(k[1]), "r"(k[2]), "r"(k[3]));
+            } else {
+                if (d_base < half_rot) {
+                    uint64_t src_k2 = src_k + half_rot * 2;
+                    uint32_t k2[4];
+                    asm volatile("ld.global.v4.u32 {%0, %1, %2, %3}, [%4];" : "=r"(k2[0]), "=r"(k2[1]), "=r"(k2[2]), "=r"(k2[3]) : "l"(src_k2));
+
+                    #pragma unroll
+                    for (int i = 0; i < 4; ++i) {
+                        int d = d_base + i * 2;
+
+                        if (d >= half_rot) continue;
+
+                        float x0_0 = __half2float(__ushort_as_half((k[i] & 0xFFFF)));
+                        float x1_0 = __half2float(__ushort_as_half((k2[i] & 0xFFFF)));
+                        float c0   = __half2float(ROTARY_COS[pos * half_rot + d]);
+                        float s0   = __half2float(ROTARY_SIN[pos * half_rot + d]);
+                        float y0_0 = __fmaf_rn(x0_0, c0, -x1_0 * s0);
+                        float y1_0 = __fmaf_rn(x0_0, s0,  x1_0 * c0);
+
+                        float x0_1 = __half2float(__ushort_as_half((k[i] >> 16)));
+                        float x1_1 = __half2float(__ushort_as_half((k2[i] >> 16)));
+                        float c1   = __half2float(ROTARY_COS[pos * half_rot + d + 1]);
+                        float s1   = __half2float(ROTARY_SIN[pos * half_rot + d + 1]);
+                        float y0_1 = __fmaf_rn(x0_1, c1, -x1_1 * s1);
+                        float y1_1 = __fmaf_rn(x0_1, s1,  x1_1 * c1);
+
+                        k[i]  = (__half_as_ushort(__float2half_rn(y0_1)) << 16) | __half_as_ushort(__float2half_rn(y0_0));
+                        k2[i] = (__half_as_ushort(__float2half_rn(y1_1)) << 16) | __half_as_ushort(__float2half_rn(y1_0));
+                    }
+                    uint64_t dst_k2 = dst_k + half_rot * 2;
+                    asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_k), "r"(k[0]), "r"(k[1]), "r"(k[2]), "r"(k[3]));
+                    asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_k2), "r"(k2[0]), "r"(k2[1]), "r"(k2[2]), "r"(k2[3]));
+                } else if (d_base >= ROTARY_DIM) {
+                    asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_k), "r"(k[0]), "r"(k[1]), "r"(k[2]), "r"(k[3]));
+                }
+            }
+        } else {
+            asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_k), "r"(k[0]), "r"(k[1]), "r"(k[2]), "r"(k[3]));
+        }
+        asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};" : : "l"(dst_v), "r"(v[0]), "r"(v[1]), "r"(v[2]), "r"(v[3]));
+    }
+}
+
+// ======================================================================================
+// TILE LOADER + ROTARY
+// ======================================================================================
+template<typename Config, int SMEM_STRIDE, bool IS_CAUSAL, bool IS_WINDOW, bool IS_ROPE, bool IS_INTERLEAVED, int GLOBAL_WIDTH = -1>
+__device__ __forceinline__ void WMMA_GEMM_TILE_ROTARY(
+    const __half* __restrict__ GMEM,
+          __half* __restrict__ SMEM,
+    const __half* __restrict__ ROTARY_COS,
+    const __half* __restrict__ ROTARY_SIN,
+    int GLOBAL_STRIDE,
+    int VALID_ROWS,
+    int CACHE_SEQLEN,
+    int ROTARY_DIM,
+    int LEFTPAD,
+    int THREAD_ID
+) {
+    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+    constexpr int dst_stride_uint4  = (SMEM_STRIDE + 7) >> 3;
+    const     int wth_stride_uint4  = (((GLOBAL_WIDTH > 0) ? GLOBAL_WIDTH : GLOBAL_STRIDE) + 7) >> 3;
+    const     int src_stride_uint4  = (GLOBAL_STRIDE + 7) >> 3;
+    const     int total_iters       = VALID_ROWS * wth_stride_uint4;
+
+    if (total_iters == 0) return;
+
+    const int q_rope_stride = (IS_CAUSAL || IS_WINDOW) ? 1 : 0;
+    const int half_rot      = IS_ROPE ? (ROTARY_DIM / 2) : 0;
+
+    uint64_t src_base = static_cast<uint64_t>(__cvta_generic_to_global(GMEM));
+    uint32_t dst_base = static_cast<uint32_t>(__cvta_generic_to_shared(SMEM));
+
+    #pragma unroll 2
+    for (int idx = THREAD_ID; idx < total_iters; idx += THREADS_PER_BLOCK) {
+        const int row = idx / wth_stride_uint4;
+        const int col = idx % wth_stride_uint4;
+
+        const int src_off = row * src_stride_uint4 + col;
+        const int dst_off = row * dst_stride_uint4 + col;
+
+        uint64_t src_addr = src_base + (static_cast<uint64_t>(src_off) << 4);
+        uint32_t dst_addr = dst_base + (static_cast<uint32_t>(dst_off) << 4);
+
+        uint32_t r[4];
+        asm volatile("ld.global.v4.u32 {%0, %1, %2, %3}, [%4];"
+                     : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3])
+                     : "l"(src_addr) : "memory");
+
+        if constexpr(IS_ROPE) {
+            const int pos    = CACHE_SEQLEN + LEFTPAD + row * q_rope_stride;
+            const int d_base = col * 8;
+
+            if constexpr (IS_INTERLEAVED) {
+                #pragma unroll
+                for (int i = 0; i < 4; ++i) {
+                    int d = d_base + i * 2;
+
+                    if (d >= ROTARY_DIM) break;
+
+                    half2 x   = *reinterpret_cast<half2*>(&r[i]);
+                    float2 xf = __half22float2(x);
+                    float c   = __half2float(ROTARY_COS[pos * half_rot + d / 2]);
+                    float s   = __half2float(ROTARY_SIN[pos * half_rot + d / 2]);
+                    float y0  = __fmaf_rn(xf.x, c, -xf.y * s);
+                    float y1  = __fmaf_rn(xf.x, s,  xf.y * c);
+                    half2 y   = __float22half2_rn(make_float2(y0, y1));
+                    r[i]      = *reinterpret_cast<uint32_t*>(&y);
+                }
+                asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};"
+                             : : "r"(dst_addr), "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]) : "memory");
+            } else {
+                if (d_base < half_rot) {
+                    uint64_t src_r2 = src_addr + half_rot * 2;
+                    uint32_t r2[4];
+                    asm volatile("ld.global.v4.u32 {%0, %1, %2, %3}, [%4];"
+                                 : "=r"(r2[0]), "=r"(r2[1]), "=r"(r2[2]), "=r"(r2[3])
+                                 : "l"(src_r2) : "memory");
+
+                    #pragma unroll
+                    for (int i = 0; i < 4; ++i) {
+                        int d = d_base + i * 2;
+
+                        if (d >= half_rot) continue;
+
+                        float x0_0 = __half2float(__ushort_as_half((r[i] & 0xFFFF)));
+                        float x1_0 = __half2float(__ushort_as_half((r2[i] & 0xFFFF)));
+                        float c0   = __half2float(ROTARY_COS[pos * half_rot + d]);
+                        float s0   = __half2float(ROTARY_SIN[pos * half_rot + d]);
+                        float y0_0 = __fmaf_rn(x0_0, c0, -x1_0 * s0);
+                        float y1_0 = __fmaf_rn(x0_0, s0,  x1_0 * c0);
+
+                        float x0_1 = __half2float(__ushort_as_half((r[i] >> 16)));
+                        float x1_1 = __half2float(__ushort_as_half((r2[i] >> 16)));
+                        float c1   = __half2float(ROTARY_COS[pos * half_rot + d + 1]);
+                        float s1   = __half2float(ROTARY_SIN[pos * half_rot + d + 1]);
+                        float y0_1 = __fmaf_rn(x0_1, c1, -x1_1 * s1);
+                        float y1_1 = __fmaf_rn(x0_1, s1,  x1_1 * c1);
+
+                        r[i]  = (__half_as_ushort(__float2half_rn(y0_1)) << 16) | __half_as_ushort(__float2half_rn(y0_0));
+                        r2[i] = (__half_as_ushort(__float2half_rn(y1_1)) << 16) | __half_as_ushort(__float2half_rn(y1_0));
+                    }
+                    uint32_t dst_r2 = dst_addr + half_rot * 2;
+                    asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};"
+                                 : : "r"(dst_addr), "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]) : "memory");
+                    asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};"
+                                 : : "r"(dst_r2), "r"(r2[0]), "r"(r2[1]), "r"(r2[2]), "r"(r2[3]) : "memory");
+                } else if (d_base >= ROTARY_DIM) {
+                    asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};"
+                                 : : "r"(dst_addr), "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]) : "memory");
+                }
+            }
+        } else {
+            asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};"
+                         : : "r"(dst_addr), "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]) : "memory");
+        }
+    }
+}

--- a/include/template.h
+++ b/include/template.h
@@ -243,49 +243,44 @@ struct BlockInfo {
 };
 
 // ======================================================================================
+// Internal recursive dispatcher: accumulates runtime flags into a compile-time pack
+// ======================================================================================
+template <typename LaunchFn, bool... Resolved>
+__host__ inline void dispatch_flags(LaunchFn& launch) {
+    launch(std::integral_constant<bool, Resolved>{}...);
+}
+
+template <typename LaunchFn, bool... Resolved, typename... Rest>
+__host__ inline void dispatch_flags(LaunchFn& launch, bool next, Rest... rest) {
+    if (next) {
+        dispatch_flags<LaunchFn, Resolved..., true>(launch, rest...);
+    } else {
+        dispatch_flags<LaunchFn, Resolved..., false>(launch, rest...);
+    }
+}
+
+// ======================================================================================
 // Runtime / Compile-Time Dispatcher
 // ======================================================================================
 template <typename LaunchFn>
 __host__ inline void dispatch_attention_features(
-    bool is_causal, bool is_alibi, bool is_softcap, bool is_window, bool is_dropout,
+    bool is_causal,
+    bool is_alibi,
+    bool is_softcap,
+    bool is_window,
+    bool is_dropout,
+    bool is_paged,
     LaunchFn&& launch)
 {
-    const bool call_alibi   = is_causal && is_alibi;
-    const bool call_softcap = is_causal && is_softcap;
-    const bool call_window  = is_causal && is_window;
-    const bool call_dropout = is_dropout;
+    const bool chk_causal  = is_causal;
+    const bool chk_alibi   = is_causal && is_alibi;
+    const bool chk_softcap = is_causal && is_softcap;
+    const bool chk_window  = is_causal && is_window;
+    const bool chk_dropout = is_dropout;
+    const bool chk_paged   = is_paged;
 
-    const int mask = (call_alibi ? 1 : 0) | (call_softcap ? 2 : 0) | (call_window ? 4 : 0) | (call_dropout ? 8 : 0);
-
-    #define CALL(C, A, S, W, D) \
-        launch(std::integral_constant<bool, C>{}, \
-               std::integral_constant<bool, A>{}, \
-               std::integral_constant<bool, S>{}, \
-               std::integral_constant<bool, W>{}, \
-               std::integral_constant<bool, D>{})
-
-    if (!is_causal) {
-        if (call_dropout) CALL(false, false, false, false, true);
-        else              CALL(false, false, false, false, false);
-    } else {
-        switch (mask) {
-            case 0:  CALL(true, false, false, false, false); break;
-            case 1:  CALL(true, true,  false, false, false); break;
-            case 2:  CALL(true, false, true,  false, false); break;
-            case 3:  CALL(true, true,  true,  false, false); break;
-            case 4:  CALL(true, false, false, true,  false); break;
-            case 5:  CALL(true, true,  false, true,  false); break;
-            case 6:  CALL(true, false, true,  true,  false); break;
-            case 7:  CALL(true, true,  true,  true,  false); break;
-            case 8:  CALL(true, false, false, false, true);  break;
-            case 9:  CALL(true, true,  false, false, true);  break;
-            case 10: CALL(true, false, true,  false, true);  break;
-            case 11: CALL(true, true,  true,  false, true);  break;
-            case 12: CALL(true, false, false, true,  true);  break;
-            case 13: CALL(true, true,  false, true,  true);  break;
-            case 14: CALL(true, false, true,  true,  true);  break;
-            case 15: CALL(true, true,  true,  true,  true);  break;
-        }
-    }
-    #undef CALL
+    dispatch_flags<LaunchFn>(
+        launch,
+        chk_causal, chk_alibi, chk_softcap, chk_window, chk_dropout, chk_paged
+    );
 }

--- a/include/template.h
+++ b/include/template.h
@@ -270,17 +270,21 @@ __host__ inline void dispatch_attention_features(
     bool is_window,
     bool is_dropout,
     bool is_paged,
+    bool is_rope,
+    bool is_interleaved,
     LaunchFn&& launch)
 {
-    const bool chk_causal  = is_causal;
-    const bool chk_alibi   = is_causal && is_alibi;
-    const bool chk_softcap = is_causal && is_softcap;
-    const bool chk_window  = is_causal && is_window;
-    const bool chk_dropout = is_dropout;
-    const bool chk_paged   = is_paged;
+    const bool chk_causal      = is_causal;
+    const bool chk_alibi       = is_alibi;
+    const bool chk_window      = is_window;
+    const bool chk_softcap     = is_softcap && !is_dropout;
+    const bool chk_dropout     = is_dropout && !is_softcap;
+    const bool chk_paged       = is_paged;
+    const bool chk_rope        = is_rope;
+    const bool chk_interleaved = is_rope && is_interleaved;
 
     dispatch_flags<LaunchFn>(
         launch,
-        chk_causal, chk_alibi, chk_softcap, chk_window, chk_dropout, chk_paged
+        chk_causal, chk_alibi, chk_softcap, chk_window, chk_dropout, chk_paged, chk_rope, chk_interleaved
     );
 }

--- a/kernel/fused_mha_api.cpp
+++ b/kernel/fused_mha_api.cpp
@@ -15,6 +15,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.doc() = "FlashAttention implementation optimized for Volta";
     m.def("fwd", &flash_attention_forward,  "FlashAttention Forward Pass");
     m.def("bwd", &flash_attention_backward, "FlashAttention Backward Pass");
-    m.def("varlen_fwd", &flash_attention_varlen_forward,  "FlashAttention Forward Pass  (variable length)");
-    m.def("varlen_bwd", &flash_attention_varlen_backward, "FlashAttention Backward Pass (variable length)");
+    m.def("varlen_fwd",  &flash_attention_varlen_forward,  "FlashAttention Forward Pass  (variable length)");
+    m.def("varlen_bwd",  &flash_attention_varlen_backward, "FlashAttention Backward Pass (variable length)");
+    m.def("fwd_kvcache", &flash_attention_kvcache, "Forward pass, with KV-cache");
 }

--- a/kernel/fused_mha_backward.cu
+++ b/kernel/fused_mha_backward.cu
@@ -45,6 +45,7 @@ flash_attention_backward_kernel(
     const float    softmax_scale,
     const float    softcap,
     const float*   alibi_slopes,
+    const int      alibi_batch,
     int            window_left,
     int            window_right,
     const float    p_dropout,
@@ -101,8 +102,9 @@ flash_attention_backward_kernel(
         const int tid     = threadIdx.x;
         const int warp_id = tid >> 5;
         const int lane_id = tid & 31;
-        // Alibi slope only for valid block
-        const float alibi_slope = (alibi_slopes) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
+        // Alibi slope only for valid block + batch
+        const int   alibi_idx   = (alibi_batch > 0) ? (block.batch_idx * alibi_batch + block.head_idx) : block.head_idx;
+        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
         // ==================================================================================
         // Layout:
@@ -355,7 +357,9 @@ flash_attention_backward_kernel(
             const __half* __restrict__ o_ptr   = O           + (size_t)((bthd_idx / H_K) * H_Q + (((bthd_idx % H_K) * (H_Q / H_K)) + group)) * M * D;
             const __half* __restrict__ dO_ptr  = dO          + (size_t)((bthd_idx / H_K) * H_Q + (((bthd_idx % H_K) * (H_Q / H_K)) + group)) * M * D;
             const  float* __restrict__ lse_ptr = softmax_lse + (size_t)((bthd_idx / H_K) * H_Q + (((bthd_idx % H_K) * (H_Q / H_K)) + group)) * M;
-            const  float           alibi_slope = (alibi_slopes) ? alibi_slopes[((bthd_idx / H_K) * H_Q + (bthd_idx % H_K) * (H_Q / H_K) + group) % H_Q] : 0.0f;
+            // Alibi slope only for valid block + batch
+            const int   alibi_idx   = (alibi_batch > 0) ? ((bthd_idx / H_K) * alibi_batch + ((bthd_idx % H_K) * (H_Q / H_K) + group)) : (bthd_idx % H_K) * (H_Q / H_K) + group;
+            const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
             // ==================================================================================
             // Q-TILES LOOP (Iterate over Q-tiles for the current Q-head)
@@ -503,6 +507,7 @@ void launcher_flash_attention_backward(
     float softcap,
     float p_dropout,
     const float* alibi_slopes,
+    const int    alibi_batch,
     int window_left,
     int window_right,
     uint64_t dropout_seed,
@@ -558,7 +563,7 @@ void launcher_flash_attention_backward(
             q_ptr, k_ptr, v_ptr, o_ptr, dO_ptr, lse_ptr,
             dQ_ptr, dK_ptr, dV_ptr,
             B, H_Q, H_K, M, N, grid_dq, grid_dkv,
-            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            softmax_scale, softcap, alibi_slopes, alibi_batch, window_left, window_right,
             p_dropout, dropout_seed, dropout_offset
         );
     });
@@ -627,6 +632,7 @@ std::vector<at::Tensor> flash_attention_backward(
 
     // Alibi slopes validation
     const float* alibi = nullptr;
+    int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
         auto sizes = slopes.sizes();
@@ -635,6 +641,7 @@ std::vector<at::Tensor> flash_attention_backward(
         bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
                            (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
         TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
         alibi = slopes.data_ptr<float>();
     }
 
@@ -676,7 +683,7 @@ std::vector<at::Tensor> flash_attention_backward(
 
     #define LAUNCH_KERNEL(DIM) \
         launcher_flash_attention_backward<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_fp16, dv_fp16, softmax_scale, is_causal, \
-                                               softcap, p_dropout, alibi, window_left, window_right, dropout_seed, dropout_offset, stream);
+                                               softcap, p_dropout, alibi, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;

--- a/kernel/fused_mha_backward.cu
+++ b/kernel/fused_mha_backward.cu
@@ -548,8 +548,8 @@ void launcher_flash_attention_backward(
     __half*       dK_ptr  = reinterpret_cast<__half*>(dK.data_ptr());
     __half*       dV_ptr  = reinterpret_cast<__half*>(dV.data_ptr());
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged, is_rope, is_interleaved,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto /*PAGED*/, auto /*ROPE*/, auto /*INTERLEAVED*/) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_backward.cu
+++ b/kernel/fused_mha_backward.cu
@@ -531,6 +531,7 @@ void launcher_flash_attention_backward(
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
+    bool is_paged   = false;
 
     const __half* q_ptr   = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr   = reinterpret_cast<const __half*>(K.data_ptr());
@@ -542,8 +543,8 @@ void launcher_flash_attention_backward(
     __half*       dK_ptr  = reinterpret_cast<__half*>(dK.data_ptr());
     __half*       dV_ptr  = reinterpret_cast<__half*>(dV.data_ptr());
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_backward.cu
+++ b/kernel/fused_mha_backward.cu
@@ -532,11 +532,13 @@ void launcher_flash_attention_backward(
     const dim3 grid(grid_max, 2, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
 
-    bool is_alibi   = (alibi_slopes != nullptr);
-    bool is_softcap = (softcap > 0.0f);
-    bool is_window  = (window_left >= 0 || window_right >= 0);
-    bool is_dropout = (p_dropout > 0.0f);
-    bool is_paged   = false;
+    bool is_alibi       = (alibi_slopes != nullptr);
+    bool is_softcap     = (softcap > 0.0f);
+    bool is_window      = (window_left >= 0 || window_right >= 0);
+    bool is_dropout     = (p_dropout > 0.0f);
+    bool is_paged       = false;
+    bool is_rope        = false;
+    bool is_interleaved = false;
 
     const __half* q_ptr   = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr   = reinterpret_cast<const __half*>(K.data_ptr());
@@ -593,61 +595,65 @@ std::vector<at::Tensor> flash_attention_backward(
     std::optional<at::Generator> gen,
     std::optional<at::Tensor>& rng_state
 ) {
-    // Device guard multi-GPU / pipeline-parallelism
+    // Device guard for multi-GPU / pipeline-parallelism
     at::cuda::CUDAGuard device_guard{q.device()};
 
     auto props = at::cuda::getCurrentDeviceProperties();
     TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
-    TORCH_CHECK(!deterministic, "Deterministic not supported in this Volta build");
+    TORCH_CHECK(!deterministic, "Deterministic backward not supported in this Volta build");
 
-    // Check layouts
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
-    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    // dtype / device / contiguity
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == q_dtype && v.dtype() == q_dtype, "k/v must have the same dtype as q");
+    TORCH_CHECK(out.dtype() == q_dtype, "out must have the same dtype as q");
+    TORCH_CHECK(dout.dtype() == q_dtype, "dout must have the same dtype as q");
     TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
 
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors q, k, v must be on CUDA");
     TORCH_CHECK(out.is_cuda() && dout.is_cuda() && softmax_lse.is_cuda(), "out, dout, softmax_lse must be on CUDA");
     TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
     TORCH_CHECK(out.stride(-1) == 1 && dout.stride(-1) == 1, "Last dim of out, dout must be contiguous");
 
-    // Variables
-    const auto sizes = q.sizes();
-    const int B      = sizes[0];
-    const int H_Q    = sizes[1];
-    const int M      = sizes[2];
-    const int D      = sizes[3];
-    const int H_K    = k.size(1);
-    const int N      = k.size(2);
+    // dimensions
+    const int B   = q.size(0);
+    const int H_Q = q.size(1);
+    const int M   = q.size(2);
+    const int D   = q.size(3);
+    const int H_K = k.size(1);
+    const int N   = k.size(2);
 
-    TORCH_CHECK(B > 0, "batch_size must be positive");
-    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be <=256 and a multiple of 8");
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 256, "head dimension must be <= 256");
+    TORCH_CHECK(D % 8 == 0, "head dimension must be multiple of 8");
     TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
 
-    // Window edge cases
-    if (window_left  >= N) { window_left  = -1; }
-    if (window_right >= N) { window_right = -1; }
+    // softcap restrictions
+    if (softcap > 0.f) {
+        TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout");
+    }
 
-    // Alibi slopes validation
-    const float* alibi = nullptr;
+    // window edge cases
+    if (window_left  >= N) window_left  = -1;
+    if (window_right >= N) window_right = -1;
+
+    // alibi
+    const float* alibi_ptr = nullptr;
     int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
-        auto sizes = slopes.sizes();
         TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
-                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
-        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
-        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
-        alibi = slopes.data_ptr<float>();
+        auto sizes = slopes.sizes();
+        bool valid = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                     (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid, "alibi_slopes must be [H_Q] or [B, H_Q]");
+        alibi_batch = (sizes.size() == 2) ? slopes.stride(0) : 0;
+        alibi_ptr = slopes.data_ptr<float>();
     }
 
-    // Dropout
+    // dropout
     TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
-    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
 
     uint64_t dropout_seed   = 0;
     uint64_t dropout_offset = 0;
@@ -659,17 +665,34 @@ std::vector<at::Tensor> flash_attention_backward(
         dropout_offset = static_cast<uint64_t>(rng_acc[1]);
     }
 
-    // Output tensors
+    // output tensors
     at::Tensor dq_fp16 = dq.has_value() ? dq.value() : torch::empty_like(q);
     at::Tensor dk_fp16 = dk.has_value() ? dk.value() : torch::empty_like(k);
-    at::Tensor dv_fp16 = dv.has_value() ? dv.value() : torch::empty_like(v);
-    TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
-    TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
-    TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
+    at::Tensor dv_fp16 = dv.has_value() ? dv.value() : torch::empty_like(k);
 
+    TORCH_CHECK(dq_fp16.dtype() == q_dtype, "dq must have the same dtype as q");
+    TORCH_CHECK(dk_fp16.dtype() == q_dtype, "dk must have the same dtype as q");
+    TORCH_CHECK(dv_fp16.dtype() == q_dtype, "dv must have the same dtype as q");
+    TORCH_CHECK(dq_fp16.is_cuda() && dk_fp16.is_cuda() && dv_fp16.is_cuda(), "d*/v* must be on CUDA");
+    TORCH_CHECK(dq_fp16.stride(-1) == 1, "dq must have contiguous last dimension");
+    TORCH_CHECK(dk_fp16.stride(-1) == 1, "dk must have contiguous last dimension");
+    TORCH_CHECK(dv_fp16.stride(-1) == 1, "dv must have contiguous last dimension");
+
+    if (dq.has_value()) {
+        TORCH_CHECK(dq_fp16.sizes() == q.sizes(), "dq shape must match q shape");
+    }
+    if (dk.has_value()) {
+        TORCH_CHECK(dk_fp16.sizes() == k.sizes(), "dk shape must match k shape");
+    }
+    if (dv.has_value()) {
+        TORCH_CHECK(dv_fp16.sizes() == k.sizes(), "dv shape must match k shape");
+    }
+
+    // dsoftmax_sum
     auto dsoftmax_sum = torch::empty({B, H_Q, M}, torch::dtype(torch::kFloat32).device(q.device()));
+    TORCH_CHECK(dsoftmax_sum.dtype() == torch::kFloat32, "dsoftmax_sum must be fp32");
 
-    // Edge-case early return
+    // empty case
     if (M == 0 || N == 0) {
         dq_fp16.zero_();
         dk_fp16.zero_();
@@ -678,12 +701,12 @@ std::vector<at::Tensor> flash_attention_backward(
         return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
     }
 
-    // Run kernel
+    // run kernel
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     #define LAUNCH_KERNEL(DIM) \
         launcher_flash_attention_backward<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_fp16, dv_fp16, softmax_scale, is_causal, \
-                                               softcap, p_dropout, alibi, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
+                                               softcap, p_dropout, alibi_ptr, alibi_batch,  window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -616,8 +616,8 @@ void launcher_flash_attention_backward_varlen(
     const int*    cu_seqlens_q_ptr = cu_seqlens_q.data_ptr<int>();
     const int*    cu_seqlens_k_ptr = cu_seqlens_k.data_ptr<int>();
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged, is_rope, is_interleaved,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED, auto /*ROPE*/, auto /*INTERLEAVED*/) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -69,8 +69,9 @@ flash_attention_backward_varlen_kernel(
         // ======================================================================================
         // Grid Mapping: 1D X for Q-blocks, Z for heads. Batch resolved device-side.
         // ======================================================================================
-        const int block_idx    = blockIdx.x;
-        const int bthd_idx     = blockIdx.z;
+        const int block_idx     = blockIdx.x;
+        const int bthd_idx      = blockIdx.z;
+
         if (bthd_idx >= B * H_Q) return;
 
         // ======================================================================================
@@ -121,7 +122,7 @@ flash_attention_backward_varlen_kernel(
         const int lane_id = tid & 31;
 
         // Alibi slope for current head
-        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
+        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
 
         // ======================================================================================
         // RAGGED POINTERS
@@ -298,8 +299,8 @@ flash_attention_backward_varlen_kernel(
         // ======================================================================================
         // Grid Mapping: 1D X for KV-blocks, Z for bthd_idx. Batch resolved device-side.
         // ======================================================================================
-        const int block_idx    = blockIdx.x;
-        const int bthd_idx  = blockIdx.z;
+        const int block_idx     = blockIdx.x;
+        const int bthd_idx      = blockIdx.z;
 
         if (bthd_idx >= B * H_Q) return;
 

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -48,6 +48,7 @@ flash_attention_backward_varlen_kernel(
     const float    softmax_scale,
     const float    softcap,
     const float*   alibi_slopes,
+    const int      alibi_batch,
     int            window_left,
     int            window_right,
     const float    p_dropout,
@@ -120,9 +121,9 @@ flash_attention_backward_varlen_kernel(
         const int tid     = threadIdx.x;
         const int warp_id = tid >> 5;
         const int lane_id = tid & 31;
-
-        // Alibi slope for current head
-        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
+        // Alibi slope only for valid block + batch
+        const int   alibi_idx   = (alibi_batch > 0) ? (block.batch_idx * alibi_batch + block.head_idx) : block.head_idx;
+        const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
         // ======================================================================================
         // RAGGED POINTERS
@@ -406,8 +407,6 @@ flash_attention_backward_varlen_kernel(
         // Iterates over all Q-heads that map to the current KV-head
         // ======================================================================================
         for (int group = 0; group < (H_Q / H_K); ++group) {
-            const int bthd_idx = block.kv_head_idx * (H_Q / H_K) + group;
-            const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
 
             // ======================================================================================
             // RAGGED POINTERS for current Q-head
@@ -421,6 +420,9 @@ flash_attention_backward_varlen_kernel(
             const __half* __restrict__ o_ptr   = O  + q_head_off;
             const __half* __restrict__ dO_ptr  = dO + q_head_off;
             const float*  __restrict__ lse_ptr = softmax_lse + static_cast<size_t>(bthd_idx) * T_Q + block.q_base;
+            // Alibi slope only for valid block + batch
+            const int   alibi_idx   = (alibi_batch > 0) ? (block.batch_idx * alibi_batch + (block.kv_head_idx * (H_Q / H_K) + group)) : block.kv_head_idx * (H_Q / H_K) + group;
+            const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
             __half* __restrict__ dK_ptr = dK_ptr_base + static_cast<size_t>(bthd_idx) * D;
             __half* __restrict__ dV_ptr = dV_ptr_base + static_cast<size_t>(bthd_idx) * D;
@@ -573,6 +575,7 @@ void launcher_flash_attention_backward_varlen(
     float        softcap,
     float        p_dropout,
     const float* alibi_slopes,
+    const int    alibi_batch,
     int          window_left,
     int          window_right,
     uint64_t     dropout_seed,
@@ -629,7 +632,7 @@ void launcher_flash_attention_backward_varlen(
             dq_ptr, dk_ptr, dv_ptr, softmax_d_ptr,
             cu_seqlens_q_ptr, cu_seqlens_k_ptr,
             B, H_Q, H_K, T_Q, T_K, grid_dq, grid_dkv,
-            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            softmax_scale, softcap, alibi_slopes, alibi_batch, window_left, window_right,
             p_dropout, dropout_seed, dropout_offset
         );
     });
@@ -704,6 +707,7 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
 
     // Alibi
     const float* alibi = nullptr;
+    int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
         auto sizes = slopes.sizes();
@@ -712,6 +716,7 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
         bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
                            (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
         TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
         alibi = slopes.data_ptr<float>();
     }
 
@@ -759,7 +764,7 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     #define LAUNCH_KERNEL(DIM) \
         launcher_flash_attention_backward_varlen<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_expanded, dv_expanded, softmax_d, \
             cu_seqlens_q, cu_seqlens_k, T_Q, T_K, max_seqlen_q, max_seqlen_k, \
-            softmax_scale, is_causal, softcap, p_dropout, alibi, \
+            softmax_scale, is_causal, softcap, p_dropout, alibi, alibi_batch, \
             window_left, window_right, dropout_seed, dropout_offset, stream);
 
     switch (D) {

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -593,6 +593,7 @@ void launcher_flash_attention_backward_varlen(
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
+    bool is_paged   = false;
 
     const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
@@ -607,8 +608,8 @@ void launcher_flash_attention_backward_varlen(
     const int*    cu_seqlens_q_ptr = cu_seqlens_q.data_ptr<int>();
     const int*    cu_seqlens_k_ptr = cu_seqlens_k.data_ptr<int>();
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -597,11 +597,13 @@ void launcher_flash_attention_backward_varlen(
     const dim3 grid(grid_x, 2, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
 
-    bool is_alibi   = (alibi_slopes != nullptr);
-    bool is_softcap = (softcap > 0.0f);
-    bool is_window  = (window_left >= 0 || window_right >= 0);
-    bool is_dropout = (p_dropout > 0.0f);
-    bool is_paged   = false;
+    bool is_alibi       = (alibi_slopes != nullptr);
+    bool is_softcap     = (softcap > 0.0f);
+    bool is_window      = (window_left >= 0 || window_right >= 0);
+    bool is_dropout     = (p_dropout > 0.0f);
+    bool is_paged       = false;
+    bool is_rope        = false;
+    bool is_interleaved = false;
 
     const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
@@ -654,16 +656,16 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     const at::Tensor& cu_seqlens_q,
     const at::Tensor& cu_seqlens_k,
     std::optional<at::Tensor>& alibi_slopes,
-    const int   max_seqlen_q,
-    const int   max_seqlen_k,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool  zero_tensors,
-    const bool  is_causal,
-    int         window_left,
-    int         window_right,
-    const float softcap,
-    const bool  deterministic,
+    const int    max_seqlen_q,
+    const int    max_seqlen_k,
+    const float  p_dropout,
+    const float  softmax_scale,
+    const bool   zero_tensors,
+    const bool   is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    const bool   deterministic,
     std::optional<at::Generator> gen,
     std::optional<at::Tensor>& rng_state
 ) {
@@ -674,22 +676,26 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
     TORCH_CHECK(!deterministic, "Deterministic backward not supported in this Volta build");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
+    // dtype / device / contiguity
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == q_dtype && v.dtype() == q_dtype, "k/v must have the same dtype as q");
+    TORCH_CHECK(out.dtype() == q_dtype, "out must have the same dtype as q");
+    TORCH_CHECK(dout.dtype() == q_dtype, "dout must have the same dtype as q");
     TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
 
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors q, k, v must be on CUDA");
+    TORCH_CHECK(out.is_cuda() && dout.is_cuda(), "out/dout must be on CUDA");
     TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
     TORCH_CHECK(out.stride(-1) == 1 && dout.stride(-1) == 1, "Last dim of out, dout must be contiguous");
 
+    // cu_seqlens
     TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32 && cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens must be int32");
-    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA device");
+    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA");
     TORCH_CHECK(cu_seqlens_q.is_contiguous() && cu_seqlens_k.is_contiguous(), "cu_seqlens must be contiguous");
-    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D tensors");
+    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D");
 
+    // dimensions
     const int T_Q   = q.size(0);
     const int H_Q   = q.size(1);
     const int D     = q.size(2);
@@ -697,32 +703,39 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     const int H_K   = k.size(1);
     const int B     = cu_seqlens_q.size(0) - 1;
 
-    TORCH_CHECK(B > 0, "batch_size must be positive");
-    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 256, "head dimension must be <= 256");
+    TORCH_CHECK(D % 8 == 0, "head dimension must be multiple of 8");
     TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
+    TORCH_CHECK(cu_seqlens_q.size(0) == B + 1, "cu_seqlens_q size mismatch");
+    TORCH_CHECK(cu_seqlens_k.size(0) == B + 1, "cu_seqlens_k size mismatch");
 
-    // Window edge cases
+    // softcap restrictions
+    if (softcap > 0.f) {
+        TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout");
+    }
+
+    // window edge cases
     if (window_left  >= max_seqlen_k) window_left  = -1;
     if (window_right >= max_seqlen_k) window_right = -1;
 
-    // Alibi
-    const float* alibi = nullptr;
+    // alibi
+    const float* alibi_ptr = nullptr;
     int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
-        auto sizes = slopes.sizes();
         TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
-                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
-        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
-        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
-        alibi = slopes.data_ptr<float>();
+        auto sizes = slopes.sizes();
+        bool valid = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                     (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid, "alibi_slopes must be [H_Q] or [B, H_Q]");
+        alibi_batch = (sizes.size() == 2) ? slopes.stride(0) : 0;
+        alibi_ptr = slopes.data_ptr<float>();
     }
 
-    // Dropout
+    // dropout
     TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
-    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
 
     uint64_t dropout_seed   = 0;
     uint64_t dropout_offset = 0;
@@ -734,19 +747,38 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
         dropout_offset = static_cast<uint64_t>(rng_acc[1]);
     }
 
-    // Output tensors
+    // output tensors
     at::Tensor dq_fp16 = dq.has_value() ? dq.value() : torch::empty_like(q);
     at::Tensor dk_fp16 = dk.has_value() ? dk.value() : torch::empty_like(k);
     at::Tensor dv_fp16 = dv.has_value() ? dv.value() : torch::empty_like(v);
 
-    // GQA/MQA expansion buffers [T_K, H_Q, D] for deterministic host-side reduction
+    TORCH_CHECK(dq_fp16.dtype() == q_dtype, "dq must have the same dtype as q");
+    TORCH_CHECK(dk_fp16.dtype() == q_dtype, "dk must have the same dtype as q");
+    TORCH_CHECK(dv_fp16.dtype() == q_dtype, "dv must have the same dtype as q");
+    TORCH_CHECK(dq_fp16.is_cuda() && dk_fp16.is_cuda() && dv_fp16.is_cuda(), "d*/v* must be on CUDA");
+    TORCH_CHECK(dq_fp16.stride(-1) == 1, "dq must have contiguous last dimension");
+    TORCH_CHECK(dk_fp16.stride(-1) == 1, "dk must have contiguous last dimension");
+    TORCH_CHECK(dv_fp16.stride(-1) == 1, "dv must have contiguous last dimension");
+
+    if (dq.has_value()) {
+        TORCH_CHECK(dq_fp16.sizes() == q.sizes(), "dq shape must match q shape");
+    }
+    if (dk.has_value()) {
+        TORCH_CHECK(dk_fp16.sizes() == k.sizes(), "dk shape must match k shape");
+    }
+    if (dv.has_value()) {
+        TORCH_CHECK(dv_fp16.sizes() == k.sizes(), "dv shape must match k shape");
+    }
+
+    // GQA/MQA expansion buffers
     at::Tensor dk_expanded = (H_K != H_Q) ? torch::empty({T_K, H_Q, D}, q.options()) : dk_fp16;
     at::Tensor dv_expanded = (H_K != H_Q) ? torch::empty({T_K, H_Q, D}, q.options()) : dv_fp16;
 
-    // dLSE tensor matches forward LSE layout [H_Q, T_Q]
+    // dLSE tensor
     auto softmax_d = torch::empty({H_Q, T_Q}, torch::dtype(torch::kFloat32).device(q.device()));
+    TORCH_CHECK(softmax_d.dtype() == torch::kFloat32, "softmax_d must be fp32");
 
-    // Edge-case return
+    // zero tensors / empty case
     if (zero_tensors) {
         dq_fp16.zero_();
         dk_expanded.zero_();
@@ -758,15 +790,13 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
         return {dq_fp16, dk_fp16, dv_fp16, softmax_d};
     }
 
-    // Run kernel
+    // run kernel
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     #define LAUNCH_KERNEL(DIM) \
-        launcher_flash_attention_backward_varlen<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_expanded, dv_expanded, softmax_d, \
-            cu_seqlens_q, cu_seqlens_k, T_Q, T_K, max_seqlen_q, max_seqlen_k, \
-            softmax_scale, is_causal, softcap, p_dropout, alibi, alibi_batch, \
-            window_left, window_right, dropout_seed, dropout_offset, stream);
-
+        launcher_flash_attention_backward_varlen<DIM>(q, k, v, out, dout, softmax_lse, dq_fp16, dk_expanded, dv_expanded, softmax_d, cu_seqlens_q, cu_seqlens_k, \
+                                                      T_Q, T_K, max_seqlen_q, max_seqlen_k, softmax_scale, is_causal, softcap, p_dropout, alibi_ptr, alibi_batch, \
+                                                       window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;
@@ -777,7 +807,7 @@ std::vector<at::Tensor> flash_attention_varlen_backward(
     }
     #undef LAUNCH_KERNEL
 
-    // Reduce expanded gradients for GQA/MQA
+    // reduce expanded gradients for GQA/MQA
     if (H_K != H_Q) {
         at::sum_out(dk_fp16, at::reshape(dk_expanded, {T_K, H_K, H_Q / H_K, D}), {2});
         at::sum_out(dv_fp16, at::reshape(dv_expanded, {T_K, H_K, H_Q / H_K, D}), {2});

--- a/kernel/fused_mha_backward_varlen.cu
+++ b/kernel/fused_mha_backward_varlen.cu
@@ -71,7 +71,7 @@ flash_attention_backward_varlen_kernel(
         // ======================================================================================
         const int block_idx    = blockIdx.x;
         const int bthd_idx     = blockIdx.z;
-        if (bthd_idx >= H_Q) return;
+        if (bthd_idx >= B * H_Q) return;
 
         // ======================================================================================
         // BlockInfo: Metadata resolution
@@ -130,12 +130,12 @@ flash_attention_backward_varlen_kernel(
         //   K/V:       [T_K, H_K, D]            offset follows k_base (K, H_K, D)
         //   LSE/dLSE:  [H_Q, T_Q]               offset follows bthd_idx * T_Q (H_Q, T_Q)
         // ======================================================================================
-        const __half* __restrict__ q_ptr   = Q  + block.q_offset(D, H_Q, T_Q);
+        const __half* __restrict__ q_ptr   = Q  + block.q_offset (D, H_Q, T_Q);
         const __half* __restrict__ k_ptr   = K  + block.kv_offset(D, H_K, T_K);
         const __half* __restrict__ v_ptr   = V  + block.kv_offset(D, H_K, T_K);
-        const __half* __restrict__ o_ptr   = O  + block.q_offset(D, H_Q, T_Q);
-        const __half* __restrict__ dO_ptr  = dO + block.q_offset(D, H_Q, T_Q);
-        __half* __restrict__ dQ_ptr        = dQ + block.q_offset(D, H_Q, T_Q);
+        const __half* __restrict__ o_ptr   = O  + block.q_offset (D, H_Q, T_Q);
+        const __half* __restrict__ dO_ptr  = dO + block.q_offset (D, H_Q, T_Q);
+              __half* __restrict__ dQ_ptr  = dQ + block.q_offset (D, H_Q, T_Q);
         const float*  __restrict__ lse_ptr = softmax_lse + block.lse_offset(H_Q, T_Q);
         float*  __restrict__ dLse_ptr      = softmax_d   + block.lse_offset(H_Q, T_Q);
 
@@ -143,8 +143,11 @@ flash_attention_backward_varlen_kernel(
         // INIT SHARED MEMORY
         // ======================================================================================
         extern __shared__ char smem_raw[];
+
         WMMA_GEMM_INIT_SMEM<Config>(smem_raw);
+
         __syncthreads();
+
         auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
 
         __half* __restrict__ sQ      = smem.phase.bdq.q;
@@ -297,7 +300,8 @@ flash_attention_backward_varlen_kernel(
         // ======================================================================================
         const int block_idx    = blockIdx.x;
         const int bthd_idx  = blockIdx.z;
-        if (bthd_idx >= H_K) return;
+
+        if (bthd_idx >= B * H_Q) return;
 
         // ======================================================================================
         // BlockInfo: Metadata resolution

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -272,6 +272,7 @@ void launcher_flash_attention_forward(
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
+    bool is_paged   = false;
 
     const __half* q_ptr     = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr     = reinterpret_cast<const __half*>(K.data_ptr());
@@ -280,8 +281,8 @@ void launcher_flash_attention_forward(
            float* lse_ptr   = softmax_lse.data_ptr<float>();
           __half* dmask_ptr = dmask.numel() > 0 ? reinterpret_cast<__half*>(dmask.data_ptr()) : nullptr;
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -271,11 +271,13 @@ void launcher_flash_attention_forward(
     const dim3 grid((M + Config::DO::BLOCK_M - 1) / Config::DO::BLOCK_M, 1, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
 
-    bool is_alibi   = (alibi_slopes != nullptr);
-    bool is_softcap = (softcap > 0.0f);
-    bool is_window  = (window_left >= 0 || window_right >= 0);
-    bool is_dropout = (p_dropout > 0.0f);
-    bool is_paged   = false;
+    bool is_alibi       = (alibi_slopes != nullptr);
+    bool is_softcap     = (softcap > 0.0f);
+    bool is_window      = (window_left >= 0 || window_right >= 0);
+    bool is_dropout     = (p_dropout > 0.0f);
+    bool is_paged       = false;
+    bool is_rope        = false;
+    bool is_interleaved = false;
 
     const __half* q_ptr     = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr     = reinterpret_cast<const __half*>(K.data_ptr());
@@ -325,56 +327,64 @@ std::vector<at::Tensor> flash_attention_forward(
     // Device guard for multi-GPU / pipeline-parallelism
     at::cuda::CUDAGuard device_guard{q.device()};
 
-    auto props  = at::cuda::getCurrentDeviceProperties();
+    auto props = at::cuda::getCurrentDeviceProperties();
     TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+
+    // dtype / device / contiguity
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == q_dtype && v.dtype() == q_dtype, "k/v must have the same dtype as q");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors q, k, v must be on CUDA");
     TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
 
-    const auto sizes = q.sizes();
-    const int B      = sizes[0];
-    const int H_Q    = sizes[1];
-    const int M      = sizes[2];
-    const int D      = sizes[3];
-    const int H_K    = k.size(1);
-    const int N      = k.size(2);
+    // dimensions
+    const int B   = q.size(0);
+    const int H_Q = q.size(1);
+    const int M   = q.size(2);
+    const int D   = q.size(3);
+    const int H_K = k.size(1);
+    const int N   = k.size(2);
 
-    TORCH_CHECK(B > 0, "batch_size must be positive");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 256, "head dimension must be <= 256");
+    TORCH_CHECK(D % 8 == 0, "head dimension must be multiple of 8");
     TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
 
-    // Window edge cases
-    if (window_left  >= N) { window_left  = -1; }
-    if (window_right >= N) { window_right = -1; }
+    // causal / window optimizations
     if (M == 1 && !alibi_slopes.has_value()) { is_causal = false; }
 
-    // Alibi
-    const float* alibi = nullptr;
+    // softcap restrictions
+    if (softcap > 0.f) {
+        TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout");
+    }
+
+    // window edge cases
+    if (window_left  >= N) window_left  = -1;
+    if (window_right >= N) window_right = -1;
+
+    // alibi
+    const float* alibi_ptr = nullptr;
     int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
-        auto sizes = slopes.sizes();
-        TORCH_CHECK(slopes.dtype() == torch::kFloat32, "alibi_slopes must be fp32");
-        TORCH_CHECK(slopes.is_cuda(), "alibi_slopes must be on CUDA");
+        TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
-                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
-        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
-        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
-        alibi = slopes.data_ptr<float>();
+        auto sizes = slopes.sizes();
+        bool valid = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                     (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid, "alibi_slopes must be [H_Q] or [B, H_Q]");
+        alibi_batch = (sizes.size() == 2) ? slopes.stride(0) : 0;
+        alibi_ptr = slopes.data_ptr<float>();
     }
 
-    // Dropout
+    // dropout
     TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
     TORCH_CHECK(!return_softmax || p_dropout > 0.f, "return_softmax requires p_dropout > 0");
-    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
 
     uint64_t dropout_seed   = 0;
     uint64_t dropout_offset = 0;
+    at::Tensor rng_state = torch::empty({2}, torch::dtype(torch::kInt64).device(q.device()));
 
-    at::Tensor rng_state;
     if (p_dropout > 0.0f) {
         auto gen_cuda = at::get_generator_or_default<at::CUDAGeneratorImpl>(gen, at::cuda::detail::getDefaultCUDAGenerator());
         std::lock_guard<std::mutex> lock(gen_cuda->mutex_);
@@ -382,40 +392,43 @@ std::vector<at::Tensor> flash_attention_forward(
         dropout_offset = gen_cuda->get_offset();
         uint64_t counter_offset = static_cast<uint64_t>(B) * static_cast<uint64_t>(H_Q) * 32ULL;
         gen_cuda->set_offset(dropout_offset + counter_offset);
-        rng_state = torch::tensor(
-            {static_cast<int64_t>(dropout_seed), static_cast<int64_t>(dropout_offset)},
-            torch::dtype(torch::kInt64).device(q.device())
-        );
-    } else {
-        rng_state = torch::empty({2}, torch::dtype(torch::kInt64).device(q.device()));
+        rng_state[0] = static_cast<int64_t>(dropout_seed);
+        rng_state[1] = static_cast<int64_t>(dropout_offset);
     }
 
-    // Output tensors
+    // output tensors
     at::Tensor out_fp16 = out.has_value() ? out.value() : torch::empty_like(q);
     auto softmax_lse = torch::empty({B, H_Q, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+
+    TORCH_CHECK(out_fp16.dtype() == q_dtype, "out must have the same dtype as q");
+    TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
+    TORCH_CHECK(out_fp16.stride(-1) == 1, "out must have contiguous last dimension");
+    if (out.has_value()) {
+        TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out shape must match q shape");
+    }
     TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
 
+    // dropout mask
     at::Tensor dmask;
-    if (return_softmax && (p_dropout > 0.0f)) {
+    if (return_softmax && p_dropout > 0.0f) {
         dmask = torch::empty({B, H_Q, M, N}, q.options());
     } else {
         dmask = torch::empty({0}, q.options());
     }
 
-    // Edge-case return
+    // empty case
     if (N == 0) {
         out_fp16.zero_();
         softmax_lse.fill_(-std::numeric_limits<float>::infinity());
         return {out_fp16, softmax_lse, dmask, rng_state};
     }
 
-    // Run kernel
+    // run kernel
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     #define LAUNCH_KERNEL(DIM) \
         launcher_flash_attention_forward<DIM>(q, k, v, out_fp16, softmax_lse, dmask, softmax_scale, is_causal, \
-                                        softcap, p_dropout, alibi, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
+                                        softcap, p_dropout, alibi_ptr, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -284,8 +284,8 @@ void launcher_flash_attention_forward(
            float* lse_ptr   = softmax_lse.data_ptr<float>();
           __half* dmask_ptr = dmask.numel() > 0 ? reinterpret_cast<__half*>(dmask.data_ptr()) : nullptr;
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged, is_rope, is_interleaved,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto /*PAGED*/, auto /*ROPE*/, auto /*INTERLEAVED*/) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_forward.cu
+++ b/kernel/fused_mha_forward.cu
@@ -40,6 +40,7 @@ flash_attention_forward_kernel(
     const float    softmax_scale,
     const float    softcap,
     const float*   alibi_slopes,
+    const int      alibi_batch,
     int            window_left,
     int            window_right,
     const float    p_dropout,
@@ -90,8 +91,9 @@ flash_attention_forward_kernel(
     const int tid     = threadIdx.x;
     const int warp_id = tid >> 5;
     const int lane_id = tid & 31;
-    // Alibi slope only for valid block
-    const float alibi_slope = (alibi_slopes) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
+    // Alibi slope only for valid block + batch
+    const int   alibi_idx   = (alibi_batch > 0) ? (block.batch_idx * alibi_batch + block.head_idx) : block.head_idx;
+    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
     // ==================================================================================
     // Layout:
@@ -248,6 +250,7 @@ void launcher_flash_attention_forward(
     float        softcap,
     float        p_dropout,
     const float* alibi_slopes,
+    const int    alibi_batch,
     int          window_left,
     int          window_right,
     uint64_t     dropout_seed,
@@ -295,7 +298,7 @@ void launcher_flash_attention_forward(
         kernel<<<grid, block, smem, stream>>>(
             q_ptr, k_ptr, v_ptr, out_ptr, lse_ptr, dmask_ptr,
             B, H_Q, H_K, M, N,
-            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            softmax_scale, softcap, alibi_slopes, alibi_batch, window_left, window_right,
             p_dropout, dropout_seed, dropout_offset
         );
     });
@@ -349,6 +352,7 @@ std::vector<at::Tensor> flash_attention_forward(
 
     // Alibi
     const float* alibi = nullptr;
+    int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
         auto sizes = slopes.sizes();
@@ -358,6 +362,7 @@ std::vector<at::Tensor> flash_attention_forward(
         bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
                            (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
         TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
         alibi = slopes.data_ptr<float>();
     }
 
@@ -410,7 +415,7 @@ std::vector<at::Tensor> flash_attention_forward(
 
     #define LAUNCH_KERNEL(DIM) \
         launcher_flash_attention_forward<DIM>(q, k, v, out_fp16, softmax_lse, dmask, softmax_scale, is_causal, \
-                                        softcap, p_dropout, alibi, window_left, window_right, dropout_seed, dropout_offset, stream);
+                                        softcap, p_dropout, alibi, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;

--- a/kernel/fused_mha_forward_kvcache.cu
+++ b/kernel/fused_mha_forward_kvcache.cu
@@ -1,0 +1,654 @@
+// ======================================================================================
+// * Copyright (c) 2026, D.Skryabin / tg @ai_bond007 SPDX-License: BSD-3-Clause
+// ======================================================================================
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include <torch/extension.h>
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "template.h"
+#include "kernel.h"
+#include "forward.h"
+#include "gemm_smem.h"
+#include "mat_mul.h"
+#include "softmax.h"
+#include "rotary.h"
+
+// ======================================================================================
+// KV-CACHE FORWARD KERNEL
+// ======================================================================================
+template<int D, bool IS_CAUSAL, bool IS_ALIBI, bool IS_SOFTCAP, bool IS_WINDOW, bool IS_PAGED, bool IS_ROPE, bool IS_INTERLEAVED>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+flash_attention_kvcache_kernel(
+    const __half* __restrict__ Q,
+    const __half* __restrict__ K_new,
+    const __half* __restrict__ V_new,
+          __half* __restrict__ K_cache,
+          __half* __restrict__ V_cache,
+          __half* __restrict__ Out,
+           float* __restrict__ softmax_lse,
+    const int*    __restrict__ cache_seqlens,
+    const int*    __restrict__ cache_batch_idx,
+    const int*    __restrict__ leftpad_k,
+    const int*    __restrict__ block_table,
+    const __half* __restrict__ rotary_cos,
+    const __half* __restrict__ rotary_sin,
+    const int     B,
+    const int     H_Q,
+    const int     H_K,
+    const int     T_Q,
+    const int     T_NEW,
+    const int     max_seqlen_k,
+    const int     block_page,
+    const int     block_table_stride,
+    const int     kv_block_stride,
+    const int     rotary_dim,
+    const float   softmax_scale,
+    const float   softcap,
+    const float*  alibi_slopes,
+    const int     alibi_batch,
+    int           window_left,
+    int           window_right,
+    const int     stride_q_b, const int stride_q_s, const int stride_q_h,
+    const int     stride_k_b, const int stride_k_s, const int stride_k_h,
+    const int     stride_n_b, const int stride_n_s, const int stride_n_h,
+    const int     stride_o_b, const int stride_o_s, const int stride_o_h
+) {
+    using Config = KernelConfig<D>;
+
+    constexpr int BLOCK_M  = Config::DO::BLOCK_M;
+    constexpr int BLOCK_N  = Config::DO::BLOCK_N;
+    constexpr int D_STRIDE = Config::DO::D_STRIDE;
+    constexpr int N_STRIDE = Config::DO::N_STRIDE;
+
+    // ==================================================================================
+    // Grid Mapping: X for Q-blocks, Z for batch-head composite (batch * H_Q + head)
+    // ==================================================================================
+    const int block_idx    = blockIdx.x;
+    const int bthd_idx     = blockIdx.z;
+
+    if (bthd_idx >= B * H_Q) return;
+
+    // ======================================================================================
+    // BlockInfo: Metadata resolution
+    // ======================================================================================
+    const int batch_idx   = bthd_idx / H_Q;
+    const int head_idx    = bthd_idx % H_Q;
+    const int kv_head_idx = head_idx / (H_Q / H_K);
+
+    const int cache_bidx     = (cache_batch_idx != nullptr) ? cache_batch_idx[batch_idx] : batch_idx;
+    const int leftpad        = (leftpad_k != nullptr) ? leftpad_k[batch_idx] : 0;
+    const int cache_seqlen   = (cache_seqlens != nullptr) ? cache_seqlens[cache_bidx] : 0;
+    const int total_seqlen_k = cache_seqlen + T_NEW;
+
+    BlockInfo<IS_CAUSAL, IS_WINDOW, false> block;
+    block.init_q(
+        block_idx,       // BLOCK_IDX:      Current Q-block index (grid.x)
+        bthd_idx,        // BATCH_HEAD_ID:  Flattened batch-head index (grid.z)
+        H_Q,             // H_Q:            Number of query heads
+        H_K,             // H_K:            Number of KV heads
+        T_Q,             // T_Q:            Total query length (uniform across batch)
+        total_seqlen_k,  // T_K:            Total KV length = cache_seqlen + T_NEW
+        B,               // B:              Batch size
+        BLOCK_M,         // BLOCK_M:        Tile size along Q dimension
+        BLOCK_N,         // BLOCK_N:        Tile size along KV dimension
+        window_left,     // WINDOW_LEFT:    Left sliding window bound (-1 if disabled)
+        window_right,    // WINDOW_RIGHT:   Right sliding window bound (-1 if disabled)
+        nullptr,         // CU_SEQLENS_Q:   nullptr (even layout, no varlen)
+        nullptr,         // CU_SEQLENS_K:   nullptr (even layout, no varlen)
+        nullptr          // SEQUSED_K:      nullptr (no partial KV usage)
+    );
+
+    if (block.start_q >= block.seqlen_q || block.valid_q_rows <= 0) return;
+
+    if (block.block_min >= block.block_max || total_seqlen_k == 0) {
+        const size_t out_off = static_cast<size_t>(batch_idx) * stride_o_b +
+                               static_cast<size_t>(head_idx)  * stride_o_h + block.start_q * stride_o_s;
+        const size_t lse_off = static_cast<size_t>(batch_idx) * H_Q * T_Q +
+                               static_cast<size_t>(head_idx)  * T_Q + block.start_q;
+        for (int row = threadIdx.x; row < block.valid_q_rows; row += blockDim.x) {
+            #pragma unroll
+            for (int d = 0; d < D; ++d) Out[out_off + row * stride_o_s + d] = __float2half(0.0f);
+            softmax_lse[lse_off + row] = NEG_INF;
+        }
+        return;
+    }
+
+    // ==================================================================================
+    // Init: thread/warp/lane IDs
+    // ==================================================================================
+    const int tid     = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane_id = tid & 31;
+    // Alibi slope only for valid block + batch
+    const int   alibi_idx   = (alibi_batch > 0) ? (batch_idx * alibi_batch + head_idx) : head_idx;
+    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
+
+    // ==================================================================================
+    // KV-CACHE UPDATE
+    // ==================================================================================
+    WMMA_GEMM_UPDATE_KVCACHE<Config, D, IS_ROPE, IS_INTERLEAVED>(
+      K_new, V_new, K_cache, V_cache, rotary_cos, rotary_sin,
+      T_NEW, H_K,
+      stride_n_b, stride_n_s, stride_n_h,
+      stride_k_b, stride_k_s, stride_k_h,
+      batch_idx, kv_head_idx, cache_bidx, cache_seqlen, rotary_dim,
+      leftpad, tid);
+    __syncthreads();
+
+    // ==================================================================================
+    // RAGGED POINTERS
+    // Layout:
+    //   Q/Out: [B, T_Q, H_Q, D]       offset = batch_idx*stride_q_b + head_idx*stride_q_h + start_q*stride_q_s
+    //   LSE:   [B*H_Q, T_Q]           offset = bthd_idx*T_Q + start_q
+    // ==================================================================================
+    const size_t q_base = static_cast<size_t>(batch_idx) * stride_q_b + static_cast<size_t>(head_idx) * stride_q_h;
+    const __half* __restrict__ q_ptr   = Q + q_base + block.start_q * stride_q_s;
+          __half* __restrict__ out_ptr = Out + static_cast<size_t>(batch_idx) * stride_o_b + static_cast<size_t>(head_idx) * stride_o_h + block.start_q * stride_o_s;
+           float* __restrict__ lse_ptr = softmax_lse + static_cast<size_t>(bthd_idx) * T_Q + block.start_q;
+
+    // ==================================================================================
+    // Init: shared memory
+    // ==================================================================================
+    extern __shared__ char smem_raw[];
+
+    WMMA_GEMM_INIT_SMEM<Config>(smem_raw);
+
+    __syncthreads();
+
+    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+    __half* __restrict__ sQ      = smem.phase.fdo.q;
+    __half* __restrict__ sK      = smem.phase.fdo.reuse_kv.k;
+    __half* __restrict__ sV      = smem.phase.fdo.reuse_kv.v;
+    float*  __restrict__ sS      = smem.phase.fdo.reuse_sp.s;
+    __half* __restrict__ sP      = smem.phase.fdo.reuse_sp.p;
+    float*  __restrict__ sRowMax = smem.row_max;
+    float*  __restrict__ sRowSum = smem.row_sum;
+    float*  __restrict__ sO      = smem.phase.fdo.o;
+
+    if (tid < BLOCK_M) {
+        sRowMax[tid] = NEG_INF;
+        sRowSum[tid] = 0.0f;
+    }
+
+    // ==================================================================================
+    // Load Q tile + Rotary
+    // ==================================================================================
+    WMMA_GEMM_TILE_ROTARY<Config, D_STRIDE, IS_CAUSAL, IS_WINDOW, IS_ROPE, IS_INTERLEAVED, D>(
+      q_ptr, sQ, rotary_cos, rotary_sin,
+      stride_q_s, block.valid_q_rows,
+      cache_seqlen, rotary_dim, leftpad, tid);
+    __syncthreads();
+
+    // ==================================================================================
+    // MAIN LOOP (iterates over K/V blocks for current Q block)
+    // ==================================================================================
+    for (int block_q = block.block_min; block_q < block.block_max; ++block_q) {
+        const int start_kv      = block_q * BLOCK_N;
+        const int valid_kv_rows = min(BLOCK_N, total_seqlen_k - start_kv);
+        if (valid_kv_rows <= 0) break;
+
+        // ======================================================================================
+        // KV-CACHE (Paged vs Contiguous)
+        // ======================================================================================
+        const __half* __restrict__ k_ptr_page;
+        const __half* __restrict__ v_ptr_page;
+
+        if constexpr (IS_PAGED) {
+            const int page_idx    = (start_kv + leftpad) / block_page;
+            const int page_offset = (start_kv + leftpad) % block_page;
+            const int bt_idx      = cache_bidx * block_table_stride + page_idx;
+            const int phys_page   = block_table[bt_idx];
+            const size_t kv_load  = static_cast<size_t>(phys_page) * kv_block_stride +
+                                    static_cast<size_t>(page_offset) * stride_k_s +
+                                    static_cast<size_t>(kv_head_idx) * stride_k_h;
+            k_ptr_page = K_cache + kv_load;
+            v_ptr_page = V_cache + kv_load;
+        } else {
+            const size_t kv_load = static_cast<size_t>(cache_bidx) * stride_k_b +
+                                   static_cast<size_t>(start_kv + leftpad) * stride_k_s +
+                                   static_cast<size_t>(kv_head_idx) * stride_k_h;
+            k_ptr_page = K_cache + kv_load;
+            v_ptr_page = V_cache + kv_load;
+        }
+
+        // ======================================================================================
+        // Load:     K tile from global to sK shared memory
+        // Layout:   K: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+        // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+          k_ptr_page, sK,
+          nullptr,    nullptr,
+          stride_k_s, valid_kv_rows, tid);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  S = Q @ K^T
+        // Layout:   sQ[valid_q_rows, D_STRIDE] @ sK^T -> sS[valid_q_rows, N_STRIDE]
+        // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+        // ======================================================================================
+        WMMA_GEMM_SCORES<Config, GemmType::sQ_KT, D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, BLOCK_M, BLOCK_N, D_STRIDE, N_STRIDE>(
+          sQ, sK, sS,
+          block.valid_q_rows,  valid_kv_rows,
+          block.start_q,       start_kv,
+          block.seqlen_offset,
+          softmax_scale, softcap, alibi_slope, window_left, window_right, warp_id, lane_id);
+        __syncthreads();
+
+        // ======================================================================================
+        // Compute:  Online softmax + O rescaling (block_q > 0)
+        // Layout:   sS[valid_q_rows, N_STRIDE] -> sP[valid_q_rows, N_STRIDE]
+        //           sO[valid_q_rows, D_STRIDE] *= exp(old_max - new_max)
+        // Template: SCORE_STRIDE=N_STRIDE, HEAD_STRIDE=D_STRIDE, TILES=true (varlen tail handling)
+        // ======================================================================================
+        WMMA_GEMM_SOFTMAX<Config, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE, true>(
+          sS, sP, sO,
+          sRowMax, sRowSum,
+          block.valid_q_rows, valid_kv_rows, tid, block_q);
+        __syncthreads();
+
+        // ======================================================================================
+        // Load:     V tile from global to sV shared memory
+        // Layout:   V: global[row: BLOCK_N, H_K * D] -> shared[row: BLOCK_N, D_STRIDE]
+        // Template: DUAL_LOAD=false, SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile)
+        // ======================================================================================
+        WMMA_GEMM_LOAD_TILE<Config, false, D_STRIDE, D>(
+          v_ptr_page, sV,
+          nullptr,    nullptr,
+          stride_k_s, valid_kv_rows, tid);
+        __syncthreads();
+
+        // ==============================================================================
+        // Compute:  dO += P @ V
+        // Layout:   sP[valid_q_rows, N_STRIDE] @ sV[valid_kv_rows, D_STRIDE] += sO
+        // Template: BLOCK_M/BLOCK_N static, valid_q/valid_kv dynamic (varlen ragged tiles)
+        // ==============================================================================
+        WMMA_GEMM_GRADIENTS<Config, GemmType::dO_PV, D, BLOCK_M, BLOCK_N, N_STRIDE, D_STRIDE>(
+          sP, sV, sO,
+          block.valid_q_rows, valid_kv_rows,
+          warp_id, lane_id);
+        __syncthreads();
+    }   // END MAIN LOOP
+    // ======================================================================================
+    // Compute:  Store normalized attention output O = softmax(S) @ V
+    // Layout:   sO[row: valid_q_rows, D_STRIDE] -> out_ptr[row: valid_q_rows, H_Q * D]
+    // Template: SMEM_STRIDE=D_STRIDE, GLOBAL_WIDTH=D (varlen sub-tile store)
+    // ======================================================================================
+    WMMA_GEMM_EPILOGUE<Config, GemmType::write_dO, D_STRIDE, D>(
+      sO,      out_ptr,
+      nullptr, nullptr,
+      sRowSum, stride_o_s, block.valid_q_rows, tid);
+
+    if (tid < block.valid_q_rows) {
+        const float sum = fmaxf(sRowSum[tid], 1e-24f);
+        const size_t lse_idx = static_cast<size_t>(batch_idx) * H_Q * T_Q +
+                               static_cast<size_t>(head_idx) * T_Q +
+                               static_cast<size_t>(block.start_q + tid);
+        softmax_lse[lse_idx] = (sRowSum[tid] <= 1e-24f) ? NEG_INF : (sRowMax[tid] + logf(sum));
+    }
+}
+
+// ======================================================================================
+// LAUNCHER
+// ======================================================================================
+template<int D>
+void launcher_flash_attention_kvcache(
+    const torch::Tensor& Q,
+    const torch::Tensor& K_new,
+    const torch::Tensor& V_new,
+    const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache,
+    torch::Tensor& Out,
+    torch::Tensor& softmax_lse,
+    const torch::Tensor& cache_seqlens,
+    const torch::Tensor& cache_batch_idx,
+    const torch::Tensor& leftpad_k,
+    const torch::Tensor& block_table,
+    const torch::Tensor& rotary_cos,
+    const torch::Tensor& rotary_sin,
+    const int      T_NEW,
+    const int      max_seqlen_k,
+    const bool     is_rope,
+    const bool     is_interleaved,
+    const int      rotary_dim,
+    const float    softmax_scale,
+    const bool     is_causal,
+    const float    softcap,
+    const float*   alibi_slopes,
+    const int      alibi_batch,
+    int            window_left,
+    int            window_right,
+    const bool     is_paged,
+    cudaStream_t   stream
+) {
+    using Config = KernelConfig<D>;
+
+    const size_t smem = Config::TOTAL_SMEM;
+    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for Forward KV-Cache kernel: ", smem, " bytes (", smem / 1024, " KB)");
+
+    const int B   = Q.size(0);
+    const int T_Q = Q.size(1);
+    const int H_Q = Q.size(2);
+    const int H_K = K_cache.size(2);
+
+    const int block_page         = is_paged ? K_cache.size(1) : 1;
+    const int block_table_stride = is_paged ? block_table.stride(0) : 0;
+    const int kv_block_stride    = is_paged ? K_cache.stride(0) : 0;
+
+    const dim3 grid((T_Q + Config::DO::BLOCK_M - 1) / Config::DO::BLOCK_M, 1, B * H_Q);
+    const dim3 block(Config::THREADS_PER_BLOCK);
+
+    // Data pointers
+    const __half* q_ptr          = reinterpret_cast<const __half*>(Q.data_ptr());
+    const __half* k_new_ptr      = K_new.defined() ? reinterpret_cast<const __half*>(K_new.data_ptr()) : nullptr;
+    const __half* v_new_ptr      = V_new.defined() ? reinterpret_cast<const __half*>(V_new.data_ptr()) : nullptr;
+    __half*       k_cache_ptr    = reinterpret_cast<__half*>(K_cache.data_ptr());
+    __half*       v_cache_ptr    = reinterpret_cast<__half*>(V_cache.data_ptr());
+    __half*       out_ptr        = reinterpret_cast<__half*>(Out.data_ptr());
+    float*        lse_ptr        = softmax_lse.data_ptr<float>();
+
+    const int*    cache_seqlens_ptr   = cache_seqlens.defined() ? cache_seqlens.data_ptr<int>() : nullptr;
+    const int*    cache_batch_idx_ptr = cache_batch_idx.defined() ? cache_batch_idx.data_ptr<int>() : nullptr;
+    const int*    leftpad_k_ptr       = leftpad_k.defined() ? leftpad_k.data_ptr<int>() : nullptr;
+    const int*    block_table_ptr     = is_paged ? block_table.data_ptr<int>() : nullptr;
+    const __half* rotary_cos_ptr      = rotary_cos.defined() ? reinterpret_cast<const __half*>(rotary_cos.data_ptr()) : nullptr;
+    const __half* rotary_sin_ptr      = rotary_sin.defined() ? reinterpret_cast<const __half*>(rotary_sin.data_ptr()) : nullptr;
+
+    // Strides
+    const int stride_q_b = Q.stride(0);
+    const int stride_q_s = Q.stride(1);
+    const int stride_q_h = Q.stride(2);
+
+    const int stride_k_b = K_cache.stride(0);
+    const int stride_k_s = K_cache.stride(1);
+    const int stride_k_h = K_cache.stride(2);
+
+    const int stride_n_b = K_new.defined() ? K_new.stride(0) : 0;
+    const int stride_n_s = K_new.defined() ? K_new.stride(1) : 0;
+    const int stride_n_h = K_new.defined() ? K_new.stride(2) : 0;
+
+    const int stride_o_b = Out.stride(0);
+    const int stride_o_s = Out.stride(1);
+    const int stride_o_h = Out.stride(2);
+
+    bool is_alibi   = (alibi_slopes != nullptr);
+    bool is_softcap = (softcap > 0.0f);
+    bool is_window  = (window_left >= 0 || window_right >= 0);
+    bool is_dropout = false;
+
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged, is_rope, is_interleaved,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto /*DROPOUT*/, auto PAGED, auto ROPE, auto INTERLEAVED) {
+        constexpr bool IS_CAUSAL      = decltype(CAUSAL)::value;
+        constexpr bool IS_ALIBI       = decltype(ALIBI)::value;
+        constexpr bool IS_SOFTCAP     = decltype(SOFTCAP)::value;
+        constexpr bool IS_WINDOW      = decltype(WINDOW)::value;
+        constexpr bool IS_PAGED       = decltype(PAGED)::value;
+        constexpr bool IS_ROPE        = decltype(ROPE)::value;
+        constexpr bool IS_INTERLEAVED = decltype(INTERLEAVED)::value;
+
+        auto kernel = flash_attention_kvcache_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_PAGED, IS_ROPE, IS_INTERLEAVED>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        kernel<<<grid, block, smem, stream>>>(
+            q_ptr, k_new_ptr, v_new_ptr, k_cache_ptr, v_cache_ptr, out_ptr, lse_ptr,
+            cache_seqlens_ptr, cache_batch_idx_ptr, leftpad_k_ptr, block_table_ptr,
+            rotary_cos_ptr, rotary_sin_ptr,
+            B, H_Q, H_K, T_Q, T_NEW, max_seqlen_k,
+            block_page, block_table_stride, kv_block_stride, rotary_dim,
+            softmax_scale, softcap, alibi_slopes, alibi_batch,
+            window_left, window_right,
+            stride_q_b, stride_q_s, stride_q_h,
+            stride_k_b, stride_k_s, stride_k_h,
+            stride_n_b, stride_n_s, stride_n_h,
+            stride_o_b, stride_o_s, stride_o_h
+        );
+    });
+}
+
+// ======================================================================================
+// WRAPPER
+// ======================================================================================
+std::vector<at::Tensor> flash_attention_kvcache(
+    at::Tensor &q,
+    const at::Tensor &kcache,
+    const at::Tensor &vcache,
+    std::optional<const at::Tensor> &k,
+    std::optional<const at::Tensor> &v,
+    std::optional<const at::Tensor> &seqlens_k,
+    std::optional<const at::Tensor> &rotary_cos,
+    std::optional<const at::Tensor> &rotary_sin,
+    std::optional<const at::Tensor> &cache_batch_idx,
+    std::optional<const at::Tensor> &leftpad_k,
+    std::optional<at::Tensor> &block_table,
+    std::optional<at::Tensor> alibi_slopes,
+    std::optional<at::Tensor> &out,
+    const float  softmax_scale,
+    bool         is_causal,
+    int          window_left,
+    int          window_right,
+    const float  softcap,
+    bool         is_rotary_interleaved,
+    int          num_splits = 0
+) {
+    // Device guard for multi-GPU / pipeline-parallelism
+    at::cuda::CUDAGuard device_guard{q.device()};
+
+    auto props = at::cuda::getCurrentDeviceProperties();
+    TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
+
+    // dtype / device / contiguity
+    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(kcache.dtype() == torch::kFloat16 && vcache.dtype() == torch::kFloat16, "kcache/vcache must be fp16");
+    TORCH_CHECK(q.is_cuda() && kcache.is_cuda() && vcache.is_cuda(), "Tensors q, kcache, vcache must be on CUDA");
+    TORCH_CHECK(q.stride(-1) == 1 && kcache.stride(-1) == 1 && vcache.stride(-1) == 1, "Last dim of q, kcache, vcache must be contiguous");
+
+    // dimensions
+    const int B         = q.size(0);
+    const int T_Q       = q.size(1);
+    const int H_Q       = q.size(2);
+    const int D         = q.size(3);
+    const int H_K       = kcache.size(2);
+    const bool is_paged = block_table.has_value();
+
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 256, "head dimension must be <= 256");
+    TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
+    TORCH_CHECK(D % 8 == 0, "head dimension must be multiple of 8");
+    TORCH_CHECK(num_splits <= 1, "num_splits > 1 not supported now, for future develop");
+
+    // causal optimizations
+    if (T_Q == 1 && !alibi_slopes.has_value()) { is_causal = false; }
+    if (is_causal) { window_right = 0; }
+
+    // softcap restrictions
+    if (softcap > 0.f) {
+        TORCH_CHECK(window_left < 0 && window_right < 0, "Softcap + window not supported");
+        TORCH_CHECK(!alibi_slopes.has_value(), "Softcap + ALiBi not supported");
+    }
+
+    // paged KV
+    at::Tensor block_table_tensor;
+    int page_block_size = 1;
+    int max_seqlen_k = 0;
+
+    if (is_paged) {
+        TORCH_CHECK(!cache_batch_idx.has_value(), "Paged KVcache does not support cache_batch_idx");
+        block_table_tensor = block_table.value();
+        TORCH_CHECK(block_table_tensor.is_cuda(), "block_table must be on CUDA");
+        TORCH_CHECK(block_table_tensor.dtype() == torch::kInt32, "block_table must have dtype int32");
+        TORCH_CHECK(block_table_tensor.stride(-1) == 1, "block_table must have contiguous last dimension");
+        TORCH_CHECK(block_table_tensor.size(0) == B, "block_table batch dim must match q");
+
+        page_block_size = kcache.size(1);
+        TORCH_CHECK(page_block_size % 256 == 0, "Paged KV block size must be divisible by 256");
+
+        const int num_blocks = kcache.size(0);
+        const int max_num_blocks_per_seq = block_table_tensor.size(1);
+        max_seqlen_k = max_num_blocks_per_seq * page_block_size;
+
+        TORCH_CHECK(kcache.sizes() == vcache.sizes(), "K and V paged shapes must match");
+        TORCH_CHECK(kcache.size(0) == num_blocks, "kcache block dim mismatch");
+        TORCH_CHECK(kcache.size(1) == page_block_size, "kcache page size mismatch");
+        TORCH_CHECK(kcache.size(2) == H_K, "kcache heads mismatch");
+        TORCH_CHECK(kcache.size(3) == D, "kcache head_dim mismatch");
+    } else {
+        max_seqlen_k = kcache.size(1);
+    }
+
+    // new K/V tensors
+    at::Tensor k_tensor, v_tensor;
+    const int T_NEW = (k.has_value() && v.has_value()) ? k->size(1) : 0;
+    if (k.has_value()) {
+        TORCH_CHECK(v.has_value(), "If key is supplied, value must also be passed in");
+        TORCH_CHECK(seqlens_k.has_value(), "If key is supplied, seqlens_k must also be passed in");
+        TORCH_CHECK(T_Q <= max_seqlen_k, "If key is supplied, it must have seqlen <= the seqlen of the KV cache");
+
+        k_tensor = k.value();
+        v_tensor = v.value();
+        TORCH_CHECK(k_tensor.dtype() == q.dtype(), "Key must have the same dtype as query");
+        TORCH_CHECK(v_tensor.dtype() == q.dtype(), "Value must have the same dtype as query");
+        TORCH_CHECK(k_tensor.is_cuda() && v_tensor.is_cuda(), "k/v must be on CUDA");
+        TORCH_CHECK(k_tensor.stride(-1) == 1, "Key tensor must have contiguous last dimension");
+        TORCH_CHECK(v_tensor.stride(-1) == 1, "Value tensor must have contiguous last dimension");
+
+        int seqlen_knew = k_tensor.size(1);
+        TORCH_CHECK(k_tensor.size(0) == B, "k batch dim mismatch");
+        TORCH_CHECK(k_tensor.size(1) == T_NEW, "k seqlen mismatch");
+        TORCH_CHECK(k_tensor.size(2) == H_K, "k heads mismatch");
+        TORCH_CHECK(k_tensor.size(3) == D, "k head_dim mismatch");
+        TORCH_CHECK(v_tensor.size(0) == B, "v batch dim mismatch");
+        TORCH_CHECK(v_tensor.size(1) == T_NEW, "v seqlen mismatch");
+        TORCH_CHECK(v_tensor.size(2) == H_K, "v heads mismatch");
+        TORCH_CHECK(v_tensor.size(3) == D, "v head_dim mismatch");
+    }
+
+    // seqlens_k
+    at::Tensor seqlens_tensor;
+    if (seqlens_k.has_value()) {
+        seqlens_tensor = seqlens_k.value();
+        TORCH_CHECK(seqlens_tensor.dtype() == torch::kInt32, "seqlens_k must have dtype int32");
+        TORCH_CHECK(seqlens_tensor.is_cuda(), "seqlens_k must be on CUDA");
+        TORCH_CHECK(seqlens_tensor.is_contiguous(), "seqlens_k must be contiguous");
+        TORCH_CHECK(seqlens_tensor.dim() == 1 && seqlens_tensor.size(0) == B, "seqlens_k must be 1D with size == batch_size");
+    }
+
+    // cache_batch_idx
+    at::Tensor cbi_tensor;
+    if (cache_batch_idx.has_value()) {
+        TORCH_CHECK(!is_paged, "cache_batch_idx not supported with paged KV");
+        cbi_tensor = cache_batch_idx.value();
+        TORCH_CHECK(cbi_tensor.dtype() == torch::kInt32, "cache_batch_idx must have dtype int32");
+        TORCH_CHECK(cbi_tensor.is_cuda(), "cache_batch_idx must be on CUDA");
+        TORCH_CHECK(cbi_tensor.is_contiguous(), "cache_batch_idx must be contiguous");
+    }
+
+    // leftpad_k
+    at::Tensor leftpad_tensor;
+    if (leftpad_k.has_value()) {
+        TORCH_CHECK(!is_paged, "Paged KV and leftpad_k are not supported simultaneously");
+        leftpad_tensor = leftpad_k.value();
+        TORCH_CHECK(leftpad_tensor.dtype() == torch::kInt32, "leftpad_k must have dtype int32");
+        TORCH_CHECK(leftpad_tensor.is_cuda(), "leftpad_k must be on CUDA");
+        TORCH_CHECK(leftpad_tensor.is_contiguous(), "leftpad_k must be contiguous");
+        TORCH_CHECK(leftpad_tensor.dim() == 1 && leftpad_tensor.size(0) == B, "leftpad_k must be 1D with size == batch_size");
+    }
+
+    // Rotary
+    bool is_rope        = false;
+    bool is_interleaved = false;
+    int  rotary_dim     = 0;
+    at::Tensor cos_tensor, sin_tensor;
+    if (rotary_cos.has_value() && rotary_sin.has_value()) {
+        TORCH_CHECK(k.has_value(), "If rotary cos/sin are provided, new key/value must also be provided");
+
+        cos_tensor = rotary_cos.value();
+        sin_tensor = rotary_sin.value();
+
+        TORCH_CHECK(cos_tensor.is_cuda(), "rotary_cos must be on CUDA");
+        TORCH_CHECK(sin_tensor.is_cuda(), "rotary_sin must be on CUDA");
+        TORCH_CHECK(cos_tensor.dtype() == q.dtype(), "rotary_cos must have the same dtype as query (fp16)");
+        TORCH_CHECK(sin_tensor.dtype() == q.dtype(), "rotary_sin must have the same dtype as query (fp16)");
+        TORCH_CHECK(cos_tensor.is_contiguous(), "rotary_cos must be contiguous");
+        TORCH_CHECK(sin_tensor.is_contiguous(), "rotary_sin must be contiguous");
+
+        rotary_dim = cos_tensor.size(1) * 2;
+        TORCH_CHECK(cos_tensor.dim() == 2, "rotary_cos must be 2D");
+        TORCH_CHECK(rotary_dim <= D, "rotary_dim must be <= head_dim");
+        TORCH_CHECK(rotary_dim % 16 == 0, "rotary_dim must be divisible by 16");
+
+        const int seqlen_ro = cos_tensor.size(0);
+        TORCH_CHECK(seqlen_ro >= max_seqlen_k + T_NEW, "rotary_cos seqlen too small");
+        TORCH_CHECK(cos_tensor.size(1) == rotary_dim / 2, "rotary_cos last dim mismatch");
+        TORCH_CHECK(sin_tensor.size(0) == seqlen_ro, "rotary_sin seqlen mismatch");
+        TORCH_CHECK(sin_tensor.size(1) == rotary_dim / 2, "rotary_sin last dim mismatch");
+        is_rope        = (rotary_dim > 0);
+        is_interleaved = is_rotary_interleaved;
+    }
+
+    // Window edge cases
+    if (window_left  >= max_seqlen_k) window_left  = -1;
+    if (window_right >= max_seqlen_k) window_right = -1;
+
+    // Alibi
+    const float* alibi_ptr = nullptr;
+    int alibi_batch = 0;
+    if (alibi_slopes.has_value()) {
+        const auto& slopes = alibi_slopes.value();
+        TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
+        TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
+        auto sizes = slopes.sizes();
+        bool valid = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                     (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid, "alibi_slopes must be [H_Q] or [B, H_Q]");
+        alibi_batch = (sizes.size() == 2) ? slopes.stride(0) : 0;
+        alibi_ptr = slopes.data_ptr<float>();
+    }
+
+    // Output tensors
+    at::Tensor out_fp16 = out.has_value() ? out.value() : torch::empty_like(q);
+    auto softmax_lse = torch::empty({B, H_Q, T_Q}, torch::dtype(torch::kFloat32).device(q.device()));
+
+    TORCH_CHECK(out_fp16.dtype() == q.dtype(), "out must have the same dtype as q");
+    TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
+    TORCH_CHECK(out_fp16.stride(-1) == 1, "out must have contiguous last dimension");
+    if (out.has_value()) {
+        TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out shape must match q shape");
+    }
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+
+    // Empty case
+    if (T_Q == 0 || max_seqlen_k == 0) {
+        out_fp16.zero_();
+        softmax_lse.fill_(-std::numeric_limits<float>::infinity());
+        return {out_fp16, softmax_lse};
+    }
+
+    // Run kernel
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    #define LAUNCH_KERNEL(DIM) \
+    launcher_flash_attention_kvcache<DIM>( \
+        q, k_tensor, v_tensor, \
+        kcache, vcache, out_fp16, softmax_lse, \
+        seqlens_tensor, cbi_tensor, leftpad_tensor, block_table_tensor, \
+        cos_tensor, sin_tensor, \
+        T_NEW, max_seqlen_k, is_rope, is_interleaved, rotary_dim, \
+        softmax_scale, is_causal, softcap, alibi_ptr, alibi_batch, \
+        window_left, window_right, is_paged, stream);
+
+    switch (D) {
+        case 16:  LAUNCH_KERNEL(16); break;
+        case 32:  LAUNCH_KERNEL(32); break;
+        case 64:  LAUNCH_KERNEL(64); break;
+        case 128: LAUNCH_KERNEL(128); break;
+        case 256: LAUNCH_KERNEL(256); break;
+        default: TORCH_CHECK(false, "Unsupported D: ", D);
+    }
+    #undef LAUNCH_KERNEL
+
+    return {out_fp16, softmax_lse};
+}

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -333,6 +333,7 @@ void launcher_flash_attention_forward_varlen(
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
+    bool is_paged   = false;
 
     const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
@@ -346,8 +347,8 @@ void launcher_flash_attention_forward_varlen(
     const int*    leftpad_k_ptr    = leftpad_k.defined() ? leftpad_k.data_ptr<int>() : nullptr;
     const int*    block_table_ptr  = paged_KV ? block_table.data_ptr<int>() : nullptr;
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -23,7 +23,7 @@
 // ======================================================================================
 // FORWARD VARLEN KERNEL
 // ======================================================================================
-template<int D, bool IS_CAUSAL, bool IS_ALIBI, bool IS_SOFTCAP, bool IS_WINDOW, bool IS_DROPOUT>
+template<int D, bool IS_CAUSAL, bool IS_ALIBI, bool IS_SOFTCAP, bool IS_WINDOW, bool IS_DROPOUT, bool IS_PAGED>
 __global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
 flash_attention_forward_varlen_kernel(
     const __half* __restrict__ Q,
@@ -179,7 +179,7 @@ flash_attention_forward_varlen_kernel(
         const __half* __restrict__ k_ptr_page;
         const __half* __restrict__ v_ptr_page;
 
-        if (block_table != nullptr) {
+        if constexpr (IS_PAGED) {
             const int page_idx    = start_kv / block_page;
             const int page_offset = start_kv % block_page;
             const int bt_idx      = block.batch_idx * block_table_stride + page_idx;
@@ -333,7 +333,7 @@ void launcher_flash_attention_forward_varlen(
     bool is_softcap = (softcap > 0.0f);
     bool is_window  = (window_left >= 0 || window_right >= 0);
     bool is_dropout = (p_dropout > 0.0f);
-    bool is_paged   = false;
+    bool is_paged   = paged_KV;
 
     const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
@@ -354,8 +354,9 @@ void launcher_flash_attention_forward_varlen(
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;
         constexpr bool IS_WINDOW  = decltype(WINDOW)::value;
         constexpr bool IS_DROPOUT = decltype(DROPOUT)::value;
+        constexpr bool IS_PAGED   = decltype(PAGED)::value;
 
-        auto kernel = flash_attention_forward_varlen_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT>;
+        auto kernel = flash_attention_forward_varlen_kernel<D, IS_CAUSAL, IS_ALIBI, IS_SOFTCAP, IS_WINDOW, IS_DROPOUT, IS_PAGED>;
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
 
         kernel<<<grid, block, smem, stream>>>(

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -97,8 +97,8 @@ flash_attention_forward_varlen_kernel(
     // Writes deterministic zeros to Out and NEG_INF to LSE for numerical stability.
     // ======================================================================================
     if (block.block_min >= block.block_max || block.seqlen_k == 0) {
-        const size_t q_base   = static_cast<size_t>(block.q_base + block.start_q) * H_Q * D + static_cast<size_t>(bthd_idx) * D;
-        const size_t lse_base = static_cast<size_t>(bthd_idx) * T_Q + block.q_base + block.start_q;
+        const size_t q_base   = block.q_offset(D, H_Q, T_Q);
+        const size_t lse_base = block.lse_offset(H_Q, T_Q);
         for (int row = threadIdx.x; row < block.valid_q_rows; row += blockDim.x) {
             #pragma unroll
             for (int d = 0; d < D; ++d) {

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -48,6 +48,7 @@ flash_attention_forward_varlen_kernel(
     const float    softmax_scale,
     const float    softcap,
     const float*   alibi_slopes,
+    const int      alibi_batch,
     int            window_left,
     int            window_right,
     const float    p_dropout,
@@ -115,8 +116,9 @@ flash_attention_forward_varlen_kernel(
     const int tid       = threadIdx.x;
     const int warp_id   = tid >> 5;
     const int lane_id   = tid & 31;
-    // Alibi slope only for valid block
-    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
+    // Alibi slope only for valid block + batch
+    const int   alibi_idx   = (alibi_batch > 0) ? (block.batch_idx * alibi_batch + block.head_idx) : block.head_idx;
+    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[alibi_idx] : 0.0f;
 
     // ======================================================================================
     // RAGGED POINTERS
@@ -308,6 +310,7 @@ void launcher_flash_attention_forward_varlen(
     float        softcap,
     float        p_dropout,
     const float* alibi_slopes,
+    const int    alibi_batch,
     int          window_left,
     int          window_right,
     uint64_t     dropout_seed,
@@ -365,7 +368,7 @@ void launcher_flash_attention_forward_varlen(
             seqused_k_ptr, leftpad_k_ptr, block_table_ptr,
             B, H_Q, H_K, T_Q, max_seqlen_k,
             block_page, block_table_stride, kv_block_stride,
-            softmax_scale, softcap, alibi_slopes, window_left, window_right,
+            softmax_scale, softcap, alibi_slopes, alibi_batch, window_left, window_right,
             p_dropout, dropout_seed, dropout_offset
         );
     });
@@ -457,6 +460,7 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
 
     // Alibi
     const float* alibi = nullptr;
+    int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
         auto sizes = slopes.sizes();
@@ -465,6 +469,7 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
         bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
                            (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
         TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
+        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
         alibi = slopes.data_ptr<float>();
     }
 
@@ -519,7 +524,7 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
             cu_seqlens_q, cu_seqlens_k, seqused_k.value_or(torch::Tensor()), \
             leftpad_k.has_value() ? leftpad_k.value() : torch::Tensor(), \
             block_table_t, paged_KV, T_Q, max_seqlen_q, max_seqlen_k, \
-            softmax_scale, is_causal, softcap, p_dropout, alibi, \
+            softmax_scale, is_causal, softcap, p_dropout, alibi, alibi_batch, \
             window_left, window_right, dropout_seed, dropout_offset, stream);
 
     switch (D) {

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -332,11 +332,13 @@ void launcher_flash_attention_forward_varlen(
     const dim3 grid((max_seqlen_q + Config::DO::BLOCK_M - 1) / Config::DO::BLOCK_M, 1, B * H_Q);
     const dim3 block(Config::THREADS_PER_BLOCK);
 
-    bool is_alibi   = (alibi_slopes != nullptr);
-    bool is_softcap = (softcap > 0.0f);
-    bool is_window  = (window_left >= 0 || window_right >= 0);
-    bool is_dropout = (p_dropout > 0.0f);
-    bool is_paged   = paged_KV;
+    bool is_alibi       = (alibi_slopes != nullptr);
+    bool is_softcap     = (softcap > 0.0f);
+    bool is_window      = (window_left >= 0 || window_right >= 0);
+    bool is_dropout     = (p_dropout > 0.0f);
+    bool is_paged       = paged_KV;
+    bool is_rope        = false;
+    bool is_interleaved = false;
 
     const __half* q_ptr            = reinterpret_cast<const __half*>(Q.data_ptr());
     const __half* k_ptr            = reinterpret_cast<const __half*>(K.data_ptr());
@@ -407,75 +409,106 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
     auto props = at::cuda::getCurrentDeviceProperties();
     TORCH_CHECK(props->major == 7 && props->minor == 0, "Kernel supports only Volta GPUs.");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q, k, v must be on CUDA");
+    // dtype / device / contiguity
+    auto q_dtype = q.dtype();
+    TORCH_CHECK(q_dtype == torch::kFloat16, "q must be fp16");
+    TORCH_CHECK(k.dtype() == q_dtype && v.dtype() == q_dtype, "k/v must have the same dtype as q");
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors q, k, v must be on CUDA");
     TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim of q, k, v must be contiguous");
 
+    // dimensions
     const int T_Q = q.size(0);
     const int H_Q = q.size(1);
     const int D   = q.size(2);
     const int B   = cu_seqlens_q.size(0) - 1;
     const bool paged_KV = block_table.has_value();
 
-    at::Tensor block_table_t;
     int H_K = paged_KV ? k.size(2) : k.size(1);
     int page_block_size = paged_KV ? k.size(1) : 1;
 
-    if (paged_KV) {
-        block_table_t = block_table.value();
-        TORCH_CHECK(block_table_t.is_cuda(), "block_table must be on CUDA");
-        TORCH_CHECK(block_table_t.dtype() == torch::kInt32, "block_table must have dtype torch.int32");
-        TORCH_CHECK(block_table_t.stride(-1) == 1, "block_table must have contiguous last dimension");
-        TORCH_CHECK(page_block_size % 256 == 0, "Paged KV cache block size must be divisible by 256");
-        TORCH_CHECK(k.sizes() == v.sizes(), "K and V paged shapes must match");
-    }
-
-    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32 && cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens must be int32");
-    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA device");
-    TORCH_CHECK(cu_seqlens_q.is_contiguous() && cu_seqlens_k.is_contiguous(), "cu_seqlens must be contiguous");
-    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D tensors");
-
-    TORCH_CHECK(D <= 256 && D % 8 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 256, "head dimension must be <= 256");
+    TORCH_CHECK(D % 8 == 0, "head dimension must be multiple of 8");
     TORCH_CHECK(H_Q % H_K == 0, "H_Q must be divisible by H_K for GQA/MQA");
-    TORCH_CHECK(B > 0, "batch_size must be positive");
+    TORCH_CHECK(num_splits <= 1, "num_splits > 1 not supported");
 
-    if (seqused_k.has_value()) {
-        auto seqused = seqused_k.value();
-        TORCH_CHECK(seqused.dtype() == torch::kInt32 && seqused.is_cuda() && seqused.is_contiguous(), "seqused_k must be int32, contiguous, on CUDA");
-        TORCH_CHECK(seqused.dim() == 1 && seqused.size(0) == B, "seqused_k must be 1D with size == batch_size");
+    // causal / window optimizations
+    if (max_seqlen_q == 1 && !alibi_slopes.has_value()) { is_causal = false; }
+
+    // softcap restrictions
+    if (softcap > 0.f) {
+        TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout");
     }
 
+    // paged KV
+    at::Tensor block_table_tensor;
+    if (paged_KV) {
+        block_table_tensor = block_table.value();
+        TORCH_CHECK(block_table_tensor.is_cuda(), "block_table must be on CUDA");
+        TORCH_CHECK(block_table_tensor.dtype() == torch::kInt32, "block_table must have dtype int32");
+        TORCH_CHECK(block_table_tensor.stride(-1) == 1, "block_table must have contiguous last dimension");
+        TORCH_CHECK(page_block_size % 256 == 0, "Paged KV block size must be divisible by 256");
+
+        const int num_blocks = k.size(0);
+        const int max_num_blocks_per_seq = block_table_tensor.size(1);
+        TORCH_CHECK(block_table_tensor.size(0) == B, "block_table batch dim must match q");
+        TORCH_CHECK(k.sizes() == v.sizes(), "K and V paged shapes must match");
+        TORCH_CHECK(k.size(0) == num_blocks, "k block dim mismatch");
+        TORCH_CHECK(k.size(1) == page_block_size, "k page size mismatch");
+        TORCH_CHECK(k.size(2) == H_K, "k heads mismatch");
+        TORCH_CHECK(k.size(3) == D, "k head_dim mismatch");
+    }
+
+    // cu_seqlens
+    TORCH_CHECK(cu_seqlens_q.dtype() == torch::kInt32 && cu_seqlens_k.dtype() == torch::kInt32, "cu_seqlens must be int32");
+    TORCH_CHECK(cu_seqlens_q.is_cuda() && cu_seqlens_k.is_cuda(), "cu_seqlens must be on CUDA");
+    TORCH_CHECK(cu_seqlens_q.is_contiguous() && cu_seqlens_k.is_contiguous(), "cu_seqlens must be contiguous");
+    TORCH_CHECK(cu_seqlens_q.dim() == 1 && cu_seqlens_k.dim() == 1, "cu_seqlens must be 1D");
+    TORCH_CHECK(cu_seqlens_q.size(0) == B + 1, "cu_seqlens_q size mismatch");
+    TORCH_CHECK(cu_seqlens_k.size(0) == B + 1, "cu_seqlens_k size mismatch");
+
+    // seqused_k
+    at::Tensor seqused_tensor;
+    if (seqused_k.has_value()) {
+        seqused_tensor = seqused_k.value();
+        TORCH_CHECK(seqused_tensor.dtype() == torch::kInt32, "seqused_k must have dtype int32");
+        TORCH_CHECK(seqused_tensor.is_cuda(), "seqused_k must be on CUDA");
+        TORCH_CHECK(seqused_tensor.is_contiguous(), "seqused_k must be contiguous");
+        TORCH_CHECK(seqused_tensor.dim() == 1 && seqused_tensor.size(0) == B, "seqused_k must be 1D with size == batch_size");
+    }
+
+    // leftpad_k
+    at::Tensor leftpad_tensor;
     if (leftpad_k.has_value()) {
         TORCH_CHECK(!paged_KV, "Paged KV and leftpad_k are not supported simultaneously");
-        auto leftpad = leftpad_k.value();
-        TORCH_CHECK(leftpad.dtype() == torch::kInt32 && leftpad.is_cuda() && leftpad.is_contiguous(), "leftpad_k must be int32, contiguous, on CUDA");
-        TORCH_CHECK(leftpad.dim() == 1 && leftpad.size(0) == B, "leftpad_k must be 1D with size == batch_size");
+        leftpad_tensor = leftpad_k.value();
+        TORCH_CHECK(leftpad_tensor.dtype() == torch::kInt32, "leftpad_k must have dtype int32");
+        TORCH_CHECK(leftpad_tensor.is_cuda(), "leftpad_k must be on CUDA");
+        TORCH_CHECK(leftpad_tensor.is_contiguous(), "leftpad_k must be contiguous");
+        TORCH_CHECK(leftpad_tensor.dim() == 1 && leftpad_tensor.size(0) == B, "leftpad_k must be 1D with size == batch_size");
     }
 
-    // Window edge cases
+    // window edge cases
     if (window_left  >= max_seqlen_k) window_left  = -1;
     if (window_right >= max_seqlen_k) window_right = -1;
 
-    // Alibi
-    const float* alibi = nullptr;
+    // alibi
+    const float* alibi_ptr = nullptr;
     int alibi_batch = 0;
     if (alibi_slopes.has_value()) {
         const auto& slopes = alibi_slopes.value();
-        auto sizes = slopes.sizes();
         TORCH_CHECK(slopes.dtype() == torch::kFloat32 && slopes.is_cuda(), "alibi_slopes must be fp32 on CUDA");
         TORCH_CHECK(slopes.stride(-1) == 1, "alibi_slopes last dim must be contiguous");
-        bool valid_shape = (sizes.size() == 1 && sizes[0] == H_Q) ||
-                           (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
-        TORCH_CHECK(valid_shape, "alibi_slopes shape must be [H_Q] or [B, H_Q], got ", sizes);
-        alibi_batch = (slopes.dim() == 2) ? slopes.stride(0) : 0;
-        alibi = slopes.data_ptr<float>();
+        auto sizes = slopes.sizes();
+        bool valid = (sizes.size() == 1 && sizes[0] == H_Q) ||
+                     (sizes.size() == 2 && sizes[0] == B && sizes[1] == H_Q);
+        TORCH_CHECK(valid, "alibi_slopes must be [H_Q] or [B, H_Q]");
+        alibi_batch = (sizes.size() == 2) ? slopes.stride(0) : 0;
+        alibi_ptr = slopes.data_ptr<float>();
     }
 
-    // Dropout
+    // dropout
     TORCH_CHECK(p_dropout >= 0.f && p_dropout < 1.f, "p_dropout must be in [0, 1)");
-    if (softcap > 0.f) { TORCH_CHECK(p_dropout == 0.f, "Softcapping does not support dropout"); }
 
     uint64_t dropout_seed   = 0;
     uint64_t dropout_offset = 0;
@@ -486,18 +519,25 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
         std::lock_guard<std::mutex> lock(gen_cuda->mutex_);
         dropout_seed   = gen_cuda->current_seed();
         dropout_offset = gen_cuda->get_offset();
-        uint64_t counter_offset = static_cast<uint64_t>(T_Q) * static_cast<uint64_t>(H_Q) * 32ULL;
+        uint64_t counter_offset = static_cast<uint64_t>(B) * static_cast<uint64_t>(H_Q) * 32ULL;
         gen_cuda->set_offset(dropout_offset + counter_offset);
         rng_state[0] = static_cast<int64_t>(dropout_seed);
         rng_state[1] = static_cast<int64_t>(dropout_offset);
     }
 
-    // Output tensors
+    // output tensors
     at::Tensor out_fp16 = out.has_value() ? out.value() : torch::empty_like(q);
     auto softmax_lse = torch::empty({H_Q, T_Q}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(out_fp16.dtype()    == torch::kFloat16, "out must be fp16");
+
+    TORCH_CHECK(out_fp16.dtype() == q_dtype, "out must have the same dtype as q");
+    TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
+    TORCH_CHECK(out_fp16.stride(-1) == 1, "out must have contiguous last dimension");
+    if (out.has_value()) {
+        TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out shape must match q shape");
+    }
     TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
 
+    // dropout mask
     at::Tensor dmask;
     if (return_softmax && p_dropout > 0.0f) {
         dmask = torch::empty({T_Q, H_Q, max_seqlen_k}, q.options());
@@ -505,7 +545,7 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
         dmask = torch::empty({0}, q.options());
     }
 
-    // Edge-case return
+    // zero tensors / empty case
     if (zero_tensors) {
         out_fp16.zero_();
         softmax_lse.fill_(-std::numeric_limits<float>::infinity());
@@ -516,17 +556,13 @@ std::vector<at::Tensor> flash_attention_varlen_forward(
         return {out_fp16, softmax_lse, dmask, rng_state};
     }
 
-    // Run kernel
+    // run kernel
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
     #define LAUNCH_KERNEL(DIM) \
-        launcher_flash_attention_forward_varlen<DIM>(q, k, v, out_fp16, softmax_lse, dmask, \
-            cu_seqlens_q, cu_seqlens_k, seqused_k.value_or(torch::Tensor()), \
-            leftpad_k.has_value() ? leftpad_k.value() : torch::Tensor(), \
-            block_table_t, paged_KV, T_Q, max_seqlen_q, max_seqlen_k, \
-            softmax_scale, is_causal, softcap, p_dropout, alibi, alibi_batch, \
-            window_left, window_right, dropout_seed, dropout_offset, stream);
-
+        launcher_flash_attention_forward_varlen<DIM>(q, k, v, out_fp16, softmax_lse, dmask, cu_seqlens_q, cu_seqlens_k, seqused_tensor, leftpad_tensor, \
+                                                     block_table_tensor, paged_KV, T_Q, max_seqlen_q, max_seqlen_k, softmax_scale, is_causal, softcap, p_dropout, \
+                                                     alibi_ptr, alibi_batch, window_left, window_right, dropout_seed, dropout_offset, stream);
     switch (D) {
         case 16:  LAUNCH_KERNEL(16);  break;
         case 32:  LAUNCH_KERNEL(32);  break;

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -116,7 +116,7 @@ flash_attention_forward_varlen_kernel(
     const int warp_id   = tid >> 5;
     const int lane_id   = tid & 31;
     // Alibi slope only for valid block
-    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx] : 0.0f;
+    const float alibi_slope = (alibi_slopes != nullptr) ? alibi_slopes[bthd_idx % H_Q] : 0.0f;
 
     // ======================================================================================
     // RAGGED POINTERS

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -350,8 +350,8 @@ void launcher_flash_attention_forward_varlen(
     const int*    leftpad_k_ptr    = leftpad_k.defined() ? leftpad_k.data_ptr<int>() : nullptr;
     const int*    block_table_ptr  = paged_KV ? block_table.data_ptr<int>() : nullptr;
 
-    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged,
-    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED) {
+    dispatch_attention_features(is_causal, is_alibi, is_softcap, is_window, is_dropout, is_paged, is_rope, is_interleaved,
+    [&](auto CAUSAL, auto ALIBI, auto SOFTCAP, auto WINDOW, auto DROPOUT, auto PAGED, auto /*ROPE*/, auto /*INTERLEAVED*/) {
         constexpr bool IS_CAUSAL  = decltype(CAUSAL)::value;
         constexpr bool IS_ALIBI   = decltype(ALIBI)::value;
         constexpr bool IS_SOFTCAP = decltype(SOFTCAP)::value;

--- a/kernel/fused_mha_forward_varlen.cu
+++ b/kernel/fused_mha_forward_varlen.cu
@@ -67,7 +67,7 @@ flash_attention_forward_varlen_kernel(
     const int block_idx    = blockIdx.x;
     const int bthd_idx     = blockIdx.z;
 
-    if (bthd_idx >= H_Q) return;
+    if (bthd_idx >= B * H_Q) return;
 
     // ======================================================================================
     // BlockInfo: Metadata resolution

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ def get_ext_modules():
                 "kernel/fused_mha_forward_varlen.cu",
                 "kernel/fused_mha_backward.cu",
                 "kernel/fused_mha_backward_varlen.cu",
+                "kernel/fused_mha_forward_kvcache.cu",
             ],
             include_dirs=[this_dir / "include"],
             extra_compile_args={


### PR DESCRIPTION
* `1a62736` **Template: Reviewd with additional logic params:** Extends the template parameter pack to support dynamic feature dispatch for causal, alibi, softcap, window, dropout, paged, rope, and interleaved modes. 

* `72211b2` **Varlen: Fix batch guard forward/backward:** Corrects batch boundary validation in variable-length attention to prevent cross-sequence data leakage during forward and backward passes.

* `b037378` **Alibi: Fix varlen forward/backward OOB if B>1:** Resolves out-of-bounds memory access in Alibi slope indexing for variable-length sequences with batch size greater than one.

* `12f5e6e` **Forward/Varlen: move from runtime->compile cache:** Shifts runtime condition checks for attention features (causal, alibi, window, dropout, softcap) into compile-time template dispatch. Reduces kernel launch overhead by resolving feature flags before execution.

* `1f8492b` **Forward/Varlen: Fix early exit define with template:** Refactors early termination logic in variable-length forward pass using template-based defines.

* `ef5aa87` **Alibi: Varlen forward/backward support shape [H_Q] or [B, H_Q]:** Extends Alibi slope tensor acceptance to both 1D [H_Q] and 2D [B, H_Q] shapes for variable-length sequences.

* `07bcf45` **Template: Updated support for KV-Cache kernel:** Augments the feature dispatch system with is_paged, is_rope, and is_interleaved flags for KV-cache kernel integration.

* `e1fffca` **Wrapper: Updated and sync torch checks/vars:** Synchronizes PyTorch tensor validation logic across forward, backward, and varlen interfaces. Adds dtype, device, contiguity, and shape checks with consistent error messaging.

* `fb80348` **Forward/KVCache: Add new one forward KV-Cache kernel:**  Implements a dedicated forward kernel for incremental decoding with KV cache support. Includes RoPE-aware cache updates, paged attention via block table, and rotary position embedding with interleaved/non-interleaved modes.

* `5d1b26c` **Interface: Updated grad/flash_attn interface:** Updates Python API signatures to pass flash_attn_with_kvcache

